### PR TITLE
[NPM] Change l'événement qui déclenche la publication

### DIFF
--- a/.github/workflows/publication-npm.yml
+++ b/.github/workflows/publication-npm.yml
@@ -4,7 +4,7 @@ permissions:
 
 on:
   release:
-    types: [created]
+    types: [published]
 
 jobs:
   publication:


### PR DESCRIPTION
On tente « published » qui semble plus adapté à ce qu'on veut faire.

https://docs.github.com/en/actions/writing-workflows/choosing-when-your-workflow-runs/events-that-trigger-workflows#release