### PR TITLE
Ajoute le typage des webcomponents

### DIFF
--- a/outils/vite-plugin-genere-jsx.ts
+++ b/outils/vite-plugin-genere-jsx.ts
@@ -1,0 +1,62 @@
+import { promises as fs } from "fs";
+import * as path from "path";
+import type { Plugin } from 'vite';
+
+export default function genereJSX(): Plugin {
+	let repertoireSortie = 'build';
+	let fichierSortie = 'jsx.d.ts';
+	let repertoireComposants = 'src/lib';
+	
+	return {
+		name: "genere-types-jsx",
+		configResolved(config) {
+			if (config.build.outDir) {
+				repertoireSortie = config.build.outDir;
+				fichierSortie = path.join(repertoireSortie, fichierSortie)
+			}
+			if(config.build.lib && config.build.lib.entry) {
+				repertoireComposants = path.resolve(config.build.lib.entry.toString().replace('/index.js', ''))
+			}
+		},
+		async writeBundle() {
+			console.log(`📝 Génération des types JSX dans: ${fichierSortie}`);
+
+			try {
+				const fichiers = await fs.readdir(repertoireComposants);
+				const fichiersSvelte = fichiers.filter((file) => file.endsWith(".svelte"));
+
+				let typesJSX = `declare namespace JSX {\n\tinterface IntrinsicElements {\n`;
+
+				for (const fichier of fichiersSvelte) {
+					const chemin = path.join(repertoireComposants, fichier);
+					const contenu = await fs.readFile(chemin, "utf-8");
+					
+					const nomWebcomposant = contenu.match(/<svelte:options\s+customElement\s*=\s*"([^"]+)"/);
+					if (!nomWebcomposant) {
+						console.warn(`⚠️ Aucun <svelte:options customElement="..."> trouvé dans ${fichier}`);
+						continue;
+					}
+					const tag = nomWebcomposant[1];
+					typesJSX += `\t\t"${tag}": {\n`;
+
+					const contenuFichierType = await fs.readFile(`${chemin}.d.ts`, "utf-8");
+
+					// @ts-ignore
+					const props = [...contenuFichierType.matchAll(/props:\s*{\n\s*([^}]*)\n\s*}/g)];
+					const propsFormatees = props[0][1].split('\n').map(p => p.replaceAll('    ', ''));
+
+					for (const prop of propsFormatees) {
+						typesJSX += `\t\t\t${prop}\n`;
+					}
+					typesJSX += `\t\t};\n`;
+				}
+				typesJSX += `\t}\n}`;
+
+				await fs.mkdir(path.dirname(fichierSortie), { recursive: true });
+				await fs.writeFile(fichierSortie, typesJSX, "utf-8");
+			} catch (err) {
+				console.error("⚠️ Erreur lors de la génération des types JSX:", err);
+			}
+		},
+	};
+}

--- a/package.json
+++ b/package.json
@@ -34,6 +34,9 @@
 		".": {
 			"types": "./dist/index.d.ts",
 			"svelte": "./dist/index.js"
+		},
+		"./dist/webcomponents": {
+			"import": "./dist/webcomponents/index.iife.js"
 		}
 	},
 	"peerDependencies": {

--- a/package.json
+++ b/package.json
@@ -36,6 +36,7 @@
 			"svelte": "./dist/index.js"
 		},
 		"./dist/webcomponents": {
+			"types": "./dist/webcomponents/jsx.d.ts",
 			"import": "./dist/webcomponents/index.iife.js"
 		}
 	},

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@lab-anssi/ui-kit",
-	"version": "0.0.2",
+	"version": "0.0.3",
 	"repository": {
 		"type": "git",
 		"url": "git+https://github.com/betagouv/lab-anssi-ui-kit.git"

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -1,4 +1,3 @@
-import { svelteTesting } from '@testing-library/svelte/vite';
 import { sveltekit } from '@sveltejs/kit/vite';
 import { defineConfig } from 'vite';
 
@@ -10,32 +9,5 @@ export default defineConfig({
 				additionalData: "@use 'src/global.scss' as *; @use '../responsive' as *;"
 			}
 		}
-	},
-	test: {
-		workspace: [
-			{
-				extends: './vite.config.ts',
-				plugins: [svelteTesting()],
-
-				test: {
-					name: 'client',
-					environment: 'jsdom',
-					clearMocks: true,
-					include: ['src/**/*.svelte.{test,spec}.{js,ts}'],
-					exclude: ['src/lib/server/**'],
-					setupFiles: ['./vitest-setup-client.ts']
-				}
-			},
-			{
-				extends: './vite.config.ts',
-
-				test: {
-					name: 'server',
-					environment: 'node',
-					include: ['src/**/*.{test,spec}.{js,ts}'],
-					exclude: ['src/**/*.svelte.{test,spec}.{js,ts}']
-				}
-			}
-		]
 	}
 });

--- a/vite.webcomponents.config.ts
+++ b/vite.webcomponents.config.ts
@@ -1,7 +1,7 @@
 import { svelte } from '@sveltejs/vite-plugin-svelte';
 import { defineConfig } from 'vite';
 import { resolve } from 'path';
-import genereJSX from './outils/vite-plugin-genere-jsx';
+import genereJSX from './outils/vite-plugin-genere-jsx.js';
 
 // Ce fichier permet de build la librairie en mode "WebComponents"
 // En suivant cette issue : https://github.com/sveltejs/kit/issues/10320

--- a/vite.webcomponents.config.ts
+++ b/vite.webcomponents.config.ts
@@ -1,6 +1,7 @@
 import { svelte } from '@sveltejs/vite-plugin-svelte';
 import { defineConfig } from 'vite';
 import { resolve } from 'path';
+import genereJSX from './outils/vite-plugin-genere-jsx';
 
 // Ce fichier permet de build la librairie en mode "WebComponents"
 // En suivant cette issue : https://github.com/sveltejs/kit/issues/10320
@@ -15,5 +16,5 @@ export default defineConfig({
 		},
 		outDir: 'dist/webcomponents'
 	},
-	plugins: [svelte()]
+	plugins: [svelte(), genereJSX()]
 });


### PR DESCRIPTION
... pour React.

Afin de satisfaire le compilateur React, il faut déclarer les types de nos webcomponents sous ce format :
```ts
declare namespace JSX {
    interface IntrinsicElements {
        "mon-composant": {
	    maProps?: "conforme"|"nonConforme";
	};
    }
}
```

On écrit donc un plugin `vite` qui permet de générer ce fichier.

Il faut donc :
- Parser les fichiers "svelte" de la librairie pour obtenir le nom du webcomposant (contenu dans `<svelte:options customElement=`)
- Parser le fichier de type associé à ce composant pour en extraire les props
- Mettre en forme ces informations dans un fichier qui doit être publié via NPM