### PR TITLE
Ajoute une action permettant de déployer le Storybook manuellement depuis les Pulls Request

### DIFF
--- a/.github/workflows/publication-storybook-dev.yml
+++ b/.github/workflows/publication-storybook-dev.yml
@@ -1,0 +1,49 @@
+name: La publication du Storybook de Dev
+permissions: {}
+
+on:
+  workflow_dispatch:
+
+jobs:
+  build:
+    name: "Construis"
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Cloner le dépôt Git
+        uses: actions/checkout@v4
+
+      - name: Utiliser la version Node.js 22
+        uses: actions/setup-node@v3
+        with:
+          node-version: 22
+
+      - name: Installer les dépendances
+        run: npm ci
+
+      - name: Builder le storybook
+        run: npm run story:build
+
+      - name: Téléverser les fichiers
+        id: deployment-dev
+        uses: actions/upload-pages-artifact@v3
+        with:
+          path: ./dist-histoire
+
+  deploy:
+    name: "Déploie"
+    needs: build
+
+    permissions:
+      pages: write
+      id-token: write
+
+    environment:
+      name: github-pages
+      url: ${{ steps.deployment.outputs.page_url }}/dev
+
+    runs-on: ubuntu-latest
+    steps:
+      - name: Deploy to GitHub Pages
+        id: deployment-dev
+        uses: actions/deploy-pages@v4


### PR DESCRIPTION
... afin de pouvoir déployer un environnement de "recette" pour nos designers.

> [!IMPORTANT]
>  Pour l'instant cette action ne fonctionne pas car les branches ne peuvent pas pousser sur Github Pages. Il faudrait regarder via admin. De plus, je ne suis pas sûr que le déploiement vers `URL/dev` est possible.