### PR TITLE
Ajoute un outillage permettant d'injecter des `nonce` dans les balises de style

### DIFF
--- a/outils/vite-plugin-injecte-nonce.ts
+++ b/outils/vite-plugin-injecte-nonce.ts
@@ -1,0 +1,25 @@
+import type { Plugin } from "vite";
+
+export default function injecteNonce(): Plugin {
+  return {
+    name: "injecte-nonce",
+    enforce: "post",
+    generateBundle(_options, bundle) {
+      console.log("📝 Ajout de la gestion du Nonce");
+
+      for (const file of Object.values(bundle)) {
+        if (file.type === "chunk" && file.code) {
+          file.code = `const nonce = document.currentScript?.dataset?.nonce;\n${file.code}`;
+          // Remplace `const a = u("style");`
+          // par `const a = u("style");a.nonce=nonce;`
+          file.code = file.code.replace(
+            /const (.)\s*=\s*.\("style"\);/gm,
+            (match, nomVariable) => `${match}${nomVariable}.nonce=nonce;`,
+          );
+        }
+      }
+
+      console.log("✅");
+    },
+  };
+}

--- a/vite.webcomponents.config.ts
+++ b/vite.webcomponents.config.ts
@@ -1,7 +1,8 @@
 import { svelte } from "@sveltejs/vite-plugin-svelte";
 import { defineConfig } from "vite";
 import { resolve } from "path";
-import genereJSX from "./outils/vite-plugin-genere-jsx.js";
+import genereJSX from "./outils/vite-plugin-genere-jsx";
+import injecteNonce from "./outils/vite-plugin-injecte-nonce";
 
 // Ce fichier permet de build la librairie en mode "WebComponents"
 // En suivant cette issue : https://github.com/sveltejs/kit/issues/10320
@@ -16,5 +17,5 @@ export default defineConfig({
     },
     outDir: "dist/webcomponents",
   },
-  plugins: [svelte(), genereJSX()],
+  plugins: [svelte(), genereJSX(), injecteNonce()],
 });


### PR DESCRIPTION
Les webcomposants nous posent des problèmes de CSP, car ils injectent eux même des balises `<style>` dans le shadow DOM. Grâce à ce plugin, on ajoute un `nonce` à ces balises.

Ce nonce doit être passé lors de l'import du script via `data-nonce`.