### PR TITLE
Ajoute la possibilité d'utiliser la variable d'environnement de chemin d'assets

### DIFF
--- a/src/assets.scss
+++ b/src/assets.scss
@@ -1,0 +1,5 @@
+$assets-url-base: "/sera-remplace-pendant-le-build";
+
+@function url-asset($chemin-local) {
+  @return url("#{$assets-url-base}#{$chemin-local}");
+}

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -1,12 +1,20 @@
 import { sveltekit } from "@sveltejs/kit/vite";
-import { defineConfig } from "vite";
+import { defineConfig, loadEnv } from "vite";
+
+// On ne build jamais pour le local : allons chercher en dur les variables de PROD.
+const varEnvDeProduction = loadEnv("production", process.cwd(), "VITE_");
 
 export default defineConfig({
   plugins: [sveltekit()],
   css: {
     preprocessorOptions: {
       scss: {
-        additionalData: "@use 'src/variables.scss' as *; @use 'src/responsive' as *;",
+        additionalData: `
+          @use 'src/variables.scss' as *; 
+          @use 'src/responsive.scss' as *; 
+          @use 'src/assets.scss' as *;
+          $assets-url-base: '${varEnvDeProduction.VITE_LAB_ANSSI_UI_KIT_ASSET_BASE}'; 
+        `,
       },
     },
   },


### PR DESCRIPTION
…dans le code SCSS, permettant ainsi de définir des `background-url`, des `:before` ou autre.

S'utilise avec 
```scss
    .selecteur {
         background-url: chemin-asset('/mon/chemin/relatif')
    }
```