### PR TITLE
Correctifs sur la suite cyber pour l'intégration dans les différentes applications du Lab 

### DIFF
--- a/src/lib/suite-cyber/navigation/Navigation.svelte
+++ b/src/lib/suite-cyber/navigation/Navigation.svelte
@@ -46,7 +46,7 @@
           services={[
             {
               nom: "MonEspaceNIS2",
-              lien: `https://monespacenis2.cyber.gouv.fr?utm_campaign="suite-cyber"&utm_source="${sourceUtm}"`,
+              lien: `https://monespacenis2.cyber.gouv.fr?utm_campaign=suite-cyber&utm_source=${sourceUtm}`,
               icone: nis2,
               classeTracking: "nis2",
             },
@@ -57,7 +57,7 @@
           services={[
             {
               nom: "Le portail du CERT-FR",
-              lien: `https://www.cert.ssi.gouv.fr?utm_campaign="suite-cyber"&utm_source="${sourceUtm}"`,
+              lien: `https://www.cert.ssi.gouv.fr?utm_campaign=suite-cyber&utm_source=${sourceUtm}`,
               icone: certFr,
               classeTracking: "cert-fr",
             },
@@ -68,7 +68,7 @@
           services={[
             {
               nom: "MonServiceSécurisé",
-              lien: `https://monservicesecurise.cyber.gouv.fr?utm_campaign="suite-cyber"&utm_source="${sourceUtm}"`,
+              lien: `https://monservicesecurise.cyber.gouv.fr?utm_campaign=suite-cyber&utm_source=${sourceUtm}`,
               icone: mss,
               labels: ["Entités publiques"],
               classeTracking: "mss",
@@ -80,14 +80,14 @@
           services={[
             {
               nom: "ADS",
-              lien: `https://club.ssi.gouv.fr?utm_campaign="suite-cyber"&utm_source="${sourceUtm}"`,
+              lien: `https://club.ssi.gouv.fr?utm_campaign=suite-cyber&utm_source=${sourceUtm}`,
               icone: certFr,
               labels: ["Entités publiques", "Entités régulées"],
               classeTracking: "ads",
             },
             {
               nom: "SILENE",
-              lien: `https://club.ssi.gouv.fr?utm_campaign="suite-cyber"&utm_source="${sourceUtm}"`,
+              lien: `https://club.ssi.gouv.fr?utm_campaign=suite-cyber&utm_source=${sourceUtm}`,
               icone: certFr,
               labels: ["Entités publiques", "Entités régulées"],
               classeTracking: "silene",
@@ -99,7 +99,7 @@
           services={[
             {
               nom: "MonAideCyber",
-              lien: `https://monaide.cyber.gouv.fr?utm_campaign="suite-cyber"&utm_source="${sourceUtm}"`,
+              lien: `https://monaide.cyber.gouv.fr?utm_campaign=suite-cyber&utm_source=${sourceUtm}`,
               icone: mac,
               classeTracking: "mac",
             },
@@ -108,7 +108,7 @@
       </div>
       <a
         class="lien-externe site-anssi"
-        href="https://cyber.gouv.fr?utm_campaign='suite-cyber'&utm_source='{sourceUtm}'"
+        href="https://cyber.gouv.fr?utm_campaign=suite-cyber&utm_source={sourceUtm}"
         target="_blank"
       >
         <div>

--- a/src/lib/suite-cyber/navigation/Navigation.svelte
+++ b/src/lib/suite-cyber/navigation/Navigation.svelte
@@ -170,6 +170,7 @@
             align-items: center;
             justify-content: center;
             gap: 8px;
+            white-space: nowrap;
           }
         }
 

--- a/src/lib/suite-cyber/navigation/Navigation.svelte
+++ b/src/lib/suite-cyber/navigation/Navigation.svelte
@@ -222,6 +222,7 @@
         gap: 8px;
         padding: 4px 8px 4px 12px;
         margin: 12px;
+        font-family: "Marianne";
       }
 
       .services-anssi {


### PR DESCRIPTION
Suite à des tests d'intégrations de la suite cyber sur les différentes applications de laboratoire de l'ANSSI, nous avons appliqué des correctifs visuels :

-  Force le police Marianne sur le bouton "fermer“ de la navigation en mode mobile
-  Ajoute un propriété au label de bouton de navigation "La Suite Cyber"  afin d'éviter qu'il passe sur plusieurs lignes
- Retire les guillemets variables de trackings UTM des liens de redirection vers les différents services depuis la Suite Cyber 