### PR TITLE
[CORRECTION] Corrige le centre d'aide

### DIFF
--- a/src/lib/CentreAide.svelte
+++ b/src/lib/CentreAide.svelte
@@ -224,8 +224,8 @@
 
         &:after {
           content: '';
-          mask-image: url('src/lib/assets/icones/lien-externe.svg');
-          -webkit-mask-image: url('src/lib/assets/icones/lien-externe.svg');
+          mask-image: url-asset('/icones/lien-externe.svg');
+          -webkit-mask-image: url-asset('/icones/lien-externe.svg');
           display: flex;
           background-color: $centre-aide-font-color-bouton;
           width: 24px;

--- a/src/lib/CentreAide.svelte
+++ b/src/lib/CentreAide.svelte
@@ -5,7 +5,13 @@
   import { srcAsset } from "$lib/assets/assets";
 
   export let nomService: string;
-  export let liens: { texte: string; href: string; }[];
+  export let liens: string;
+
+  let liensMisEnForme: { texte: string; href: string; }[] = JSON.parse(liens);
+
+  if(!Array.isArray(liensMisEnForme) || liensMisEnForme.some(l => !l.texte || !l.href)) {
+    throw new Error("Les liens doivent respecter le type : { texte: string; href: string; }[]");
+  }
 
   let ouvert: boolean = false;
 </script>
@@ -33,8 +39,8 @@
       <div class="message">
         <span>Bonjour et bienvenue sur <b>{nomService}</b>. Comment pouvons-nous vous aider ?</span>
       </div>
-      {#if liens}
-        {#each liens as lien, id (id)}
+      {#if liensMisEnForme}
+        {#each liensMisEnForme as lien, id (id)}
           <a class="lien lien-principal" href={lien.href} target="_blank">{lien.texte}</a>
         {/each}
       {/if}


### PR DESCRIPTION
- Chemin des assets pour les icones (on veut utiliser S3 en prod)
- Props en `string` : un webcomponent ne peut pas faire autrement