### PR TITLE
[CORRECTION] Corrige l'affichage du lien de diagnostic cyber

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@lab-anssi/ui-kit",
-  "version": "1.5.1",
+  "version": "1.6.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@lab-anssi/ui-kit",
-      "version": "1.5.1",
+      "version": "1.6.0",
       "license": "Apache-2.0",
       "devDependencies": {
         "@eslint/compat": "^1.2.5",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@lab-anssi/ui-kit",
-  "version": "1.5.1",
+  "version": "1.6.0",
   "repository": {
     "type": "git",
     "url": "git+https://github.com/betagouv/lab-anssi-ui-kit.git"

--- a/src/lib/mes-services-cyber/lien/LienDiagnosticCyber.svelte
+++ b/src/lib/mes-services-cyber/lien/LienDiagnosticCyber.svelte
@@ -37,8 +37,7 @@
 <style lang="scss">
   .racine {
     position: relative;
-    display: flex;
-    justify-content: flex-end;
+    display: inline-block;
 
     .lien-diagnostic-cyber {
       font-size: 0.875rem;
@@ -55,6 +54,7 @@
       border: 1px solid $diagnostic-cyber-lien-color;
       border-radius: 8px;
       cursor: pointer;
+      text-wrap: nowrap;
 
       &:hover + .bloc {
         visibility: visible;

--- a/stories/mes-services-cyber/lien/LienDiagnosticCyber.story.svelte
+++ b/stories/mes-services-cyber/lien/LienDiagnosticCyber.story.svelte
@@ -7,8 +7,10 @@
 </script>
 
 <Hst.Story title="Composants/MesServicesCyber/LienDiagnosticCyber">
-  <div style="height: 600px; padding: 30px">
-    <div style="margin-left: 300px">
+  <div
+    style="height: 600px; width: 600px; padding: 30px; background-color: #f0f0f0; border-radius: 8px;"
+  >
+    <div style="margin-left: 300px;">
       <h3>Avant</h3>
       <LienDiagnosticCyber {versExterne} lien="https://" />
       <h3>Après</h3>


### PR DESCRIPTION
... Afin de permettre au conteneur de determiner l'alignement du composant pour cela on le passe en 'inline-block' comme tout bouton html.