### PR TITLE
1. Créé un composant réutilisable Brique pour les pages vitrines

### DIFF
--- a/src/lib/lab/vitrines-produits/briques/Brique.svelte
+++ b/src/lib/lab/vitrines-produits/briques/Brique.svelte
@@ -1,0 +1,38 @@
+<script lang="ts">
+  export let variation: 'primaire' = 'primaire';
+</script>
+
+<section class={variation}>
+  <div class="contenu-brique">
+    <slot />
+  </div>
+</section>
+
+<style lang="scss">
+  section {
+    font-family: Marianne;
+    padding: 48px 16px;
+    text-align: left;
+    width: calc(100vw - 32px);
+    color: white;
+
+    @include a-partir-de(tablette) {
+      padding: 72px 24px;
+      width: calc(100vw - 48px);
+    }
+
+    @include a-partir-de(desktop) {
+      padding: 48px 24px;
+      width: calc(100vw - 48px);
+    }
+
+    &.primaire {
+      background: $brique-background-primaire;
+    }
+  }
+
+  .contenu-brique {
+    max-width: 1200px;
+    margin: 0 auto;
+  }
+</style>

--- a/src/variables.scss
+++ b/src/variables.scss
@@ -22,6 +22,9 @@ $diagnostic-cyber-lien-color: var(--diagnostic-cyber-color, #0d0c21);
 $diagnostic-cyber-font-lien-color: var(--diagnostic-cyber-color, #0d0c21);
 $diagnostic-cyber-font-color: var(--diagnostic-cyber-color, #0d0c21);
 
+// - Site vitrine
+$brique-background-primaire: var(--brique-background-primaire);
+
 // Affichage
 $z-index-au-dessus: 1000;
 

--- a/stories/OutilSelecteurTheme.svelte
+++ b/stories/OutilSelecteurTheme.svelte
@@ -9,7 +9,8 @@
     "centre-aide-border-lien-secondaire",
     "centre-aide-font-color-lien-secondaire",
     "centre-aide-background-hover-lien",
-    "centre-aide-background-hover-declencheur"
+    "centre-aide-background-hover-declencheur",
+    "brique-background-primaire"
   ] as const;
   type VariablesCSS = (typeof variablesCSS)[number];
 
@@ -23,7 +24,8 @@
       "centre-aide-border-lien-secondaire": "var(--centre-aide-background-entete)",
       "centre-aide-font-color-lien-secondaire": "var(--centre-aide-background-entete)",
       "centre-aide-background-hover-lien": "#0C5C98",
-      "centre-aide-background-hover-declencheur": "var(--centre-aide-background-hover-lien)"
+      "centre-aide-background-hover-declencheur": "var(--centre-aide-background-hover-lien)",
+      "brique-background-primaire": "var(--centre-aide-background-entete)",
     },
     MonAideCyber: {
       "centre-aide-background-entete": "#5D2A9D",
@@ -32,7 +34,8 @@
       "centre-aide-border-lien-secondaire": "var(--centre-aide-background-entete)",
       "centre-aide-font-color-lien-secondaire": "var(--centre-aide-background-entete)",
       "centre-aide-background-hover-lien": "#9C51D0",
-      "centre-aide-background-hover-declencheur": "var(--centre-aide-background-hover-lien)"
+      "centre-aide-background-hover-declencheur": "var(--centre-aide-background-hover-lien)",
+      "brique-background-primaire": "var(--centre-aide-background-entete)",
     },
     MesServicesCyber: {
       "centre-aide-background-entete": '#0d0c21 url("src/lib/assets/illustrations/tuile-msc.svg") repeat top left / 500px',
@@ -41,7 +44,8 @@
       "centre-aide-border-lien-secondaire": "#0D0C21",
       "centre-aide-font-color-lien-secondaire": "var(--centre-aide-font-color-bouton)",
       "centre-aide-background-hover-lien": "#E4C274",
-      "centre-aide-background-hover-declencheur": '#22213C url("src/lib/assets/illustrations/tuile-msc.svg") repeat top left / 500px'
+      "centre-aide-background-hover-declencheur": '#22213C url("src/lib/assets/illustrations/tuile-msc.svg") repeat top left / 500px',
+      "brique-background-primaire": "var(--centre-aide-background-entete)",
     },
     MonEspaceNIS2: {
       "centre-aide-background-entete": "#272771",
@@ -50,7 +54,8 @@
       "centre-aide-border-lien-secondaire": "var(--centre-aide-background-entete)",
       "centre-aide-font-color-lien-secondaire": "var(--centre-aide-background-entete)",
       "centre-aide-background-hover-lien": "#41419F",
-      "centre-aide-background-hover-declencheur": "var(--centre-aide-background-hover-lien)"
+      "centre-aide-background-hover-declencheur": "var(--centre-aide-background-hover-lien)",
+      "brique-background-primaire": "var(--centre-aide-background-entete)",
     },
   };
 

--- a/stories/lab/vitrines-produits/briques/Brique.story.svelte
+++ b/stories/lab/vitrines-produits/briques/Brique.story.svelte
@@ -1,0 +1,14 @@
+<script lang="ts">
+  import type { Hst } from "@histoire/plugin-svelte";
+  import Brique from "$lib/lab/vitrines-produits/briques/Brique.svelte";
+  import OutilSelecteurTheme from "../../../OutilSelecteurTheme.svelte";
+  export let Hst: Hst
+</script>
+
+<Hst.Story title="Composants/Lab/Vitrines Produits/Briques" icon="token-branded:brick">
+  <OutilSelecteurTheme />
+  <Brique variation="primaire">
+    <h1>Un titre</h1>
+    <p>Du texte</p>
+  </Brique>
+</Hst.Story>


### PR DESCRIPTION
L'idée pour ce composant `<Brique></Brique>` est de pouvoir obtenir un bloc dont le fond d'écran dépendrait du thème produit sélectionné, et d'y insérer n'importe quelle contenu (voir capture ci-dessous pour le thème MesServicesCyber)

L'utilisation du composant se ferait de cette façon : 
````
<Brique variation="primaire">
    <slot />
</Brique>
````
NB : la variation primaire correspond au fond principal du produit (violet foncé pour MAC, le pattern pour MSC, ...)

Exemple avec le pattern MSC :
![image](https://github.com/user-attachments/assets/949bd81e-3ce7-4368-9dac-de8ad8a62125)

Exemple avec le fond MAC : 
![image](https://github.com/user-attachments/assets/81af0ec3-6cbc-49a8-b6ee-a25b24ea7178)

