### PR TITLE
[SOIN] Transforme les boutons d'action de la brique hero en liens de redirection cliquables

### DIFF
--- a/src/lib/lab/vitrines-produits/briques/Brique.svelte
+++ b/src/lib/lab/vitrines-produits/briques/Brique.svelte
@@ -14,17 +14,14 @@
     font-family: Marianne;
     padding: 48px 16px;
     text-align: left;
-    width: calc(100vw - 32px);
     color: white;
 
     @include a-partir-de(tablette) {
       padding: 72px 24px;
-      width: calc(100vw - 48px);
     }
 
     @include a-partir-de(desktop) {
       padding: 48px 24px;
-      width: calc(100vw - 48px);
     }
 
     &.primaire {

--- a/src/lib/lab/vitrines-produits/briques/BriqueHero.svelte
+++ b/src/lib/lab/vitrines-produits/briques/BriqueHero.svelte
@@ -116,7 +116,7 @@
           }
 
           span:before {
-            content: url('src/lib/assets/icones/succes.svg');
+            content: url-asset('/icones/succes.svg');
             display: flex;
             width: 16px;
             height: 16px;

--- a/src/lib/lab/vitrines-produits/briques/BriqueHero.svelte
+++ b/src/lib/lab/vitrines-produits/briques/BriqueHero.svelte
@@ -6,21 +6,23 @@
       soustitre: { reflect: false, type: 'String', attribute: 'soustitre' },
 			illustration: { reflect: false, type: 'Object', attribute: 'illustration' },
       badge: { reflect: false, type: 'Boolean', attribute: 'badge' },
-			actions: { reflect: false, type: 'Array', attribute: 'actions' },
+			actionGauche: { reflect: false, type: 'Object', attribute: 'actionGauche' },
+			actionDroite: { reflect: false, type: 'Object', attribute: 'actionDroite' },
 			partenaires: { reflect: false, type: 'Array', attribute: 'partenaires' },
 		}
 	}} />
 
 <script lang="ts">
   import Brique from "$lib/lab/vitrines-produits/briques/Brique.svelte";
-  import type { Actions, Image } from "$lib/types";
+  import type { Action, Image } from "$lib/types";
 
   export let titre: string;
   export let soustitre: string;
   export let illustration: Image;
 
   export let badge: boolean = false;
-  export let actions: Actions = [];
+  export let actionGauche: Action;
+  export let actionDroite: Action;
   export let partenaires: Image[] = []
 </script>
 
@@ -38,13 +40,14 @@
         <h1>{titre}</h1>
         <p>{soustitre}</p>
       </div>
-      {#if actions && actions.length > 0}
-        <div class="actions">
-          {#each actions as action}
-            <a href={action.lien} target="_blank"><button type="button" class={action.variation}>{action.titre}</button></a>
-          {/each}
-        </div>
-      {/if}
+      <div class="actions">
+        <a role="button" class="action-gauche" href={actionGauche.lien} target="_blank">
+          {actionGauche.titre}
+        </a>
+        <a role="button" class="action-droite" href={actionDroite.lien} target="_blank">
+          {actionDroite.titre}
+        </a>
+      </div>
     </div>
     <div class="image">
       <img src={illustration.lien} alt={illustration.alt} />
@@ -186,39 +189,57 @@
       }
     }
 
+    a[role='button'] {
+      text-decoration: none;
+      font-family: Marianne, sans-serif;
+      padding: 8px 16px;
+
+      text-align: center;
+      font-weight: 500;
+      font-size: 1rem;
+      line-height: 24px;
+
+      border-radius: 4px;
+
+      &.action-gauche {
+        background-color: $brique-hero-bouton-gauche-background;
+        color: $brique-hero-bouton-gauche-texte;
+        border: none;
+        cursor: pointer;
+
+        &:active {
+          background-color: $brique-hero-bouton-gauche-background-active;
+          box-shadow: none;
+          border: none;
+        }
+
+        &:hover {
+          background-color: $brique-hero-bouton-gauche-background-hover;
+          box-shadow: none;
+          border: none;
+        }
+      }
+
+      &.action-droite {
+        background-color: $brique-hero-bouton-droite-background;
+        color: $brique-hero-bouton-droite-texte;
+        border: 1px solid $brique-hero-bouton-droite-texte;
+        cursor: pointer;
+
+        &:active {
+          background-color: $brique-hero-bouton-droite-background-active;
+        }
+
+        &:hover {
+          background-color: $brique-hero-bouton-droite-background-hover;
+        }
+      }
+    }
+
     p {
       margin: 0;
       font-size: 20px;
       line-height: 32px;
-    }
-
-
-    button {
-      font-family: Marianne, sans-serif;
-      padding: 8px 16px;
-      font-size: 16px;
-      font-weight: 500;
-      line-height: 24px;
-      border-radius: 4px;
-    }
-
-    button.primaire {
-      border: none;
-      color: $centre-aide-font-color-bouton;
-      background-color: $bouton-background-primaire;
-    }
-
-    button.primaire-inverse {
-      border: none;
-      color: $centre-aide-background-entete;
-      background-color: $bouton-background-primaire-inverse;
-    }
-
-    button.secondaire {
-      border-radius: 4px;
-      border: 1px solid #FFF;
-      color: white;
-      background-color: transparent;
     }
   }
 </style>

--- a/src/lib/lab/vitrines-produits/briques/BriqueHero.svelte
+++ b/src/lib/lab/vitrines-produits/briques/BriqueHero.svelte
@@ -41,7 +41,7 @@
       {#if actions && actions.length > 0}
         <div class="actions">
           {#each actions as action}
-            <button type="button" class={action.variation}>{action.titre}</button>
+            <a href={action.lien} target="_blank"><button type="button" class={action.variation}>{action.titre}</button></a>
           {/each}
         </div>
       {/if}

--- a/src/lib/types.ts
+++ b/src/lib/types.ts
@@ -3,7 +3,7 @@ export type Image = {
   alt: string;
 };
 // eslint-disable-next-line @typescript-eslint/no-unused-vars
-export type Actions = { titre: string; lien: string; variation: "primaire" | 'primaire-inverse' | "secondaire" }[];
+export type Action = { titre: string; lien: string; };
 
 export type Tuiles = {
   titre: string;

--- a/src/variables.scss
+++ b/src/variables.scss
@@ -7,9 +7,6 @@ $texte-dsfr: #000091;
 $texte-defaut: #161616;
 $texte-secondaire: #3a3a3a;
 
-$bouton-background-primaire: var(--bouton-background-primaire);
-$bouton-background-primaire-inverse: var(--bouton-background-primaire-inverse);
-
 // Couleurs par composant
 // - Centre d'aide
 $centre-aide-background-entete: var(--centre-aide-background-entete);
@@ -28,6 +25,16 @@ $diagnostic-cyber-font-color: var(--diagnostic-cyber-color, #0d0c21);
 // - Site vitrine
 $brique-background-primaire: var(--brique-background-primaire);
 
+// - Brique Hero
+$brique-hero-bouton-gauche-background: var(--brique-hero-bouton-gauche-background);
+$brique-hero-bouton-gauche-background-hover: var(--brique-hero-bouton-gauche-background-hover);
+$brique-hero-bouton-gauche-background-active: var(--brique-hero-bouton-gauche-background-active);
+$brique-hero-bouton-gauche-texte: var(--brique-hero-bouton-gauche-texte);
+
+$brique-hero-bouton-droite-background: var(--brique-hero-bouton-droite-background);
+$brique-hero-bouton-droite-background-hover: var(--brique-hero-bouton-droite-background-hover);
+$brique-hero-bouton-droite-background-active: var(--brique-hero-bouton-droite-background-active);
+$brique-hero-bouton-droite-texte: var(--brique-hero-bouton-droite-texte);
+
 // Affichage
 $z-index-au-dessus: 1000;
-

--- a/stories/OutilSelecteurTheme.svelte
+++ b/stories/OutilSelecteurTheme.svelte
@@ -11,8 +11,14 @@
     "centre-aide-background-hover-lien",
     "centre-aide-background-hover-declencheur",
     "brique-background-primaire",
-    "bouton-background-primaire",
-    "bouton-background-primaire-inverse"
+    "brique-hero-bouton-gauche-background",
+    "brique-hero-bouton-gauche-background-hover",
+    "brique-hero-bouton-gauche-background-active",
+    "brique-hero-bouton-gauche-texte",
+    "brique-hero-bouton-droite-background",
+    "brique-hero-bouton-droite-background-hover",
+    "brique-hero-bouton-droite-background-active",
+    "brique-hero-bouton-droite-texte"
   ] as const;
   type VariablesCSS = (typeof variablesCSS)[number];
 
@@ -22,14 +28,20 @@
     MonServiceSécurisé: {
       "centre-aide-background-entete": "#0279D0",
       "centre-aide-background-bouton": "var(--centre-aide-background-entete)",
-      "centre-aide-font-color-bouton": "white",
+      "centre-aide-font-color-bouton": "#FFFFFF",
       "centre-aide-border-lien-secondaire": "var(--centre-aide-background-entete)",
       "centre-aide-font-color-lien-secondaire": "var(--centre-aide-background-entete)",
       "centre-aide-background-hover-lien": "#0C5C98",
       "centre-aide-background-hover-declencheur": "var(--centre-aide-background-hover-lien)",
       "brique-background-primaire": "var(--centre-aide-background-entete)",
-      "bouton-background-primaire": "#0279D0",
-      "bouton-background-primaire-inverse": "white"
+      "brique-hero-bouton-gauche-background": "#FFFFFF",
+      "brique-hero-bouton-gauche-background-hover": "#F6F6F6",
+      "brique-hero-bouton-gauche-background-active": "#F6F6F6",
+      "brique-hero-bouton-gauche-texte": "#0279D0",
+      "brique-hero-bouton-droite-background": "transparent",
+      "brique-hero-bouton-droite-background-hover": "rgba(255, 255, 255, 0.08)",
+      "brique-hero-bouton-droite-background-active": "rgba(255, 255, 255, 0.16)",
+      "brique-hero-bouton-droite-texte": "#FFFFFF"
     },
     MonAideCyber: {
       "centre-aide-background-entete": "#5D2A9D",
@@ -40,8 +52,14 @@
       "centre-aide-background-hover-lien": "#9C51D0",
       "centre-aide-background-hover-declencheur": "var(--centre-aide-background-hover-lien)",
       "brique-background-primaire": "var(--centre-aide-background-entete)",
-      "bouton-background-primaire": "#5D2A9D",
-      "bouton-background-primaire-inverse": "white"
+      "brique-hero-bouton-gauche-background": "white",
+      "brique-hero-bouton-gauche-background-hover": "#F6F6F6",
+      "brique-hero-bouton-gauche-background-active": "#F6F6F6",
+      "brique-hero-bouton-gauche-texte": "#5D2A9D",
+      "brique-hero-bouton-droite-background": "transparent",
+      "brique-hero-bouton-droite-background-hover": "rgba(255, 255, 255, 0.08)",
+      "brique-hero-bouton-droite-background-active": "rgba(255, 255, 255, 0.16)",
+      "brique-hero-bouton-droite-texte": "white"
     },
     MesServicesCyber: {
       "centre-aide-background-entete": '#0d0c21 url("src/lib/assets/illustrations/tuile-msc.svg") repeat top left / 500px',
@@ -52,8 +70,14 @@
       "centre-aide-background-hover-lien": "#E4C274",
       "centre-aide-background-hover-declencheur": '#22213C url("src/lib/assets/illustrations/tuile-msc.svg") repeat top left / 500px',
       "brique-background-primaire": "var(--centre-aide-background-entete)",
-      "bouton-background-primaire": "#FED980",
-      "bouton-background-primaire-inverse": "white"
+      "brique-hero-bouton-gauche-background": "#FED980",
+      "brique-hero-bouton-gauche-background-hover": "#ECCA79",
+      "brique-hero-bouton-gauche-background-active": "#DDBD70",
+      "brique-hero-bouton-gauche-texte": "#0D0C21",
+      "brique-hero-bouton-droite-background": "transparent",
+      "brique-hero-bouton-droite-background-hover": "rgba(255, 255, 255, 0.08)",
+      "brique-hero-bouton-droite-background-active": "rgba(255, 255, 255, 0.16)",
+      "brique-hero-bouton-droite-texte": "#FFFFFF"
     },
     MonEspaceNIS2: {
       "centre-aide-background-entete": "#272771",
@@ -64,8 +88,14 @@
       "centre-aide-background-hover-lien": "#41419F",
       "centre-aide-background-hover-declencheur": "var(--centre-aide-background-hover-lien)",
       "brique-background-primaire": "var(--centre-aide-background-entete)",
-      "bouton-background-primaire": "#272771",
-      "bouton-background-primaire-inverse": "white"
+      "brique-hero-bouton-gauche-background": "#FFFFFF",
+      "brique-hero-bouton-gauche-background-hover": "#FFFFFF",
+      "brique-hero-bouton-gauche-background-active": "#FFFFFF",
+      "brique-hero-bouton-gauche-texte": "#272771",
+      "brique-hero-bouton-droite-background": "transparent",
+      "brique-hero-bouton-droite-background-hover": "rgba(255, 255, 255, 0.08)",
+      "brique-hero-bouton-droite-background-active": "rgba(255, 255, 255, 0.16)",
+      "brique-hero-bouton-droite-texte": "#FFFFFF"
     },
   };
 

--- a/stories/lab/vitrines-produits/LandingMAC.story.svelte
+++ b/stories/lab/vitrines-produits/LandingMAC.story.svelte
@@ -2,24 +2,11 @@
   import type { Hst } from "@histoire/plugin-svelte";
   import BriqueHero from "$lib/lab/vitrines-produits/briques/BriqueHero.svelte";
   import OutilSelecteurTheme from "../../OutilSelecteurTheme.svelte";
-  import type { Actions, Image, Tuiles } from "$lib/types";
+  import type { Action, Image, Tuiles } from "$lib/types";
   import CarrouselTuiles from "$lib/lab/vitrines-produits/briques/CarrouselTuiles.svelte";
   import { genereImageDePlaceholder } from "$lib/generateurImagesPlaceholders";
 
   export let Hst: Hst;
-
-  const actionsDisponibles: Actions = [
-    {
-      titre: 'Devenir Aidant cyber',
-      lien: "https://monaide.cyber.gouv.fr/realiser-des-diagnostics-anssi",
-      variation: 'primaire-inverse'
-    },
-    {
-      titre: "Bénéficier d'un diagnostic cyber",
-      lien: "https://messervices.cyber.gouv.fr/cyberdepart",
-      variation: 'secondaire'
-    }
-  ]
 
   const imageAffichee: Image = {
     lien: genereImageDePlaceholder(600, 400),
@@ -59,7 +46,14 @@
   <BriqueHero titre="Mon​Aide​Cyber"
               soustitre="Des Aidants cyber mobilisés pour aider les entités publiques et privées à prendre leur cyberdépart !"
               illustration={imageAffichee}
-              actions={actionsDisponibles}
+              actionGauche={{
+                titre: 'Devenir Aidant cyber',
+                lien: "https://monaide.cyber.gouv.fr/realiser-des-diagnostics-anssi",
+              }}
+              actionDroite={{
+                titre: "Bénéficier d'un diagnostic cyber",
+                lien: "https://messervices.cyber.gouv.fr/cyberdepart",
+              }}
   />
   <CarrouselTuiles {tuiles} />
 </Hst.Story>

--- a/stories/lab/vitrines-produits/LandingMAC.story.svelte
+++ b/stories/lab/vitrines-produits/LandingMAC.story.svelte
@@ -11,12 +11,12 @@
   const actionsDisponibles: Actions = [
     {
       titre: 'Devenir Aidant cyber',
-      lien: "",
+      lien: "https://monaide.cyber.gouv.fr/realiser-des-diagnostics-anssi",
       variation: 'primaire-inverse'
     },
     {
       titre: "Bénéficier d'un diagnostic cyber",
-      lien: "",
+      lien: "https://messervices.cyber.gouv.fr/cyberdepart",
       variation: 'secondaire'
     }
   ]

--- a/stories/lab/vitrines-produits/LandingMSC.story.svelte
+++ b/stories/lab/vitrines-produits/LandingMSC.story.svelte
@@ -2,23 +2,10 @@
   import type { Hst } from "@histoire/plugin-svelte";
   import BriqueHero from "$lib/lab/vitrines-produits/briques/BriqueHero.svelte";
   import OutilSelecteurTheme from "../../OutilSelecteurTheme.svelte";
-  import type { Actions, Image } from "$lib/types";
+  import type { Action, Image } from "$lib/types";
   import { genereImageDePlaceholder } from "$lib/generateurImagesPlaceholders";
 
   export let Hst: Hst;
-
-  const actionsDisponibles: Actions = [
-    {
-      titre: 'Découvrir les services adaptés à NIS2',
-      lien: "",
-      variation: 'primaire'
-    },
-    {
-      titre: "Découvrir le catalogue complet",
-      lien: "",
-      variation: 'secondaire'
-    }
-  ]
 
   const imageAffichee: Image = {
     lien: genereImageDePlaceholder(600, 400),
@@ -33,6 +20,13 @@
   <BriqueHero titre="Mes​Services​Cyber"
               soustitre="Accédez aux services et ressources cyber proposés par l'Agence nationale de la sécurité des systèmes d'information et ses partenaires."
               illustration={imageAffichee}
-              actions={actionsDisponibles}
+              actionGauche={{
+                titre: 'Découvrir les services adaptés à NIS2',
+                lien: "",
+              }}
+              actionDroite={{
+                titre: "Découvrir le catalogue complet",
+                lien: "",
+              }}
   />
 </Hst.Story>

--- a/stories/lab/vitrines-produits/LandingMSS.story.svelte
+++ b/stories/lab/vitrines-produits/LandingMSS.story.svelte
@@ -2,23 +2,10 @@
   import type { Hst } from "@histoire/plugin-svelte";
   import BriqueHero from "$lib/lab/vitrines-produits/briques/BriqueHero.svelte";
   import OutilSelecteurTheme from "../../OutilSelecteurTheme.svelte";
-  import type { Actions, Image } from "$lib/types";
+  import type { Action, Image } from "$lib/types";
   import { genereImageDePlaceholder } from "$lib/generateurImagesPlaceholders";
 
   export let Hst: Hst;
-
-  const actionsDisponibles: Actions = [
-    {
-      titre: 'Commencer à sécuriser',
-      lien: "",
-      variation: 'primaire-inverse'
-    },
-    {
-      titre: "Être accompagné",
-      lien: "",
-      variation: 'secondaire'
-    }
-  ]
 
   const partenaires: Image[] = [
     {
@@ -40,7 +27,15 @@
   <BriqueHero titre="Mon​Service​Sécurisé"
               soustitre="L'outil pour piloter en équipe la sécurité de tous vos services numériques et les homologuer rapidement"
               illustration={imageAffichee}
-              actions={actionsDisponibles}
+              actionGauche={{
+                titre: 'Commencer à sécuriser',
+                lien: "",
+              }}
+              actionDroite={{
+                titre: "Être accompagné",
+                lien: "",
+                variation: 'secondaire'
+              }}
               badge
               {partenaires}
   />

--- a/stories/lab/vitrines-produits/briques/BriqueHero.story.svelte
+++ b/stories/lab/vitrines-produits/briques/BriqueHero.story.svelte
@@ -14,7 +14,8 @@
                 badge={proprietesDeVariantsHero['mss'].badge}
                 soustitre={proprietesDeVariantsHero['mss'].soustitre}
                 illustration={proprietesDeVariantsHero['mss'].illustration}
-                actions={proprietesDeVariantsHero['mss'].actions}
+                actionGauche={proprietesDeVariantsHero['mss'].actionGauche}
+                actionDroite={proprietesDeVariantsHero['mss'].actionDroite}
                 partenaires={proprietesDeVariantsHero['mss'].partenaires}
     />
   </Hst.Variant>
@@ -24,7 +25,8 @@
                 badge={proprietesDeVariantsHero['mac'].badge}
                 soustitre={proprietesDeVariantsHero['mac'].soustitre}
                 illustration={proprietesDeVariantsHero['mac'].illustration}
-                actions={proprietesDeVariantsHero['mac'].actions}
+                actionGauche={proprietesDeVariantsHero['mac'].actionGauche}
+                actionDroite={proprietesDeVariantsHero['mac'].actionDroite}
                 partenaires={proprietesDeVariantsHero['mac'].partenaires}
     />
   </Hst.Variant>
@@ -34,7 +36,8 @@
                 badge={proprietesDeVariantsHero['msc'].badge}
                 soustitre={proprietesDeVariantsHero['msc'].soustitre}
                 illustration={proprietesDeVariantsHero['msc'].illustration}
-                actions={proprietesDeVariantsHero['msc'].actions}
+                actionGauche={proprietesDeVariantsHero['msc'].actionGauche}
+                actionDroite={proprietesDeVariantsHero['msc'].actionDroite}
                 partenaires={proprietesDeVariantsHero['msc'].partenaires}
     />
   </Hst.Variant>

--- a/stories/lab/vitrines-produits/donneesProduits.ts
+++ b/stories/lab/vitrines-produits/donneesProduits.ts
@@ -9,18 +9,14 @@ export const proprietesDeVariantsHero = {
       lien: genereImageDePlaceholder(600, 400),
       alt: "Logo placeholder"
     },
-    actions: [
-      {
-        titre: 'Commencer à sécuriser',
-        lien: "",
-        variation: 'primaire-inverse'
-      },
-      {
-        titre: "Être accompagné",
-        lien: "",
-        variation: 'secondaire'
-      }
-    ],
+    actionGauche: {
+      titre: 'Commencer à sécuriser',
+      lien: "",
+    },
+    actionDroite: {
+      titre: "Être accompagné",
+      lien: "",
+    },
     partenaires: [
       {
         lien: 'src/lib/assets/illustrations/cnil.svg',
@@ -36,18 +32,14 @@ export const proprietesDeVariantsHero = {
       lien: genereImageDePlaceholder(600, 400),
       alt: "Logo placeholder"
     },
-    actions: [
-      {
-        titre: 'Devenir Aidant cyber',
+    actionGauche: {
+      titre: 'Devenir Aidant cyber',
         lien: "",
-        variation: 'primaire-inverse'
-      },
-      {
-        titre: "Bénéficier d'un diagnostic cyber",
+    },
+    actionDroite: {
+      titre: "Bénéficier d'un diagnostic cyber",
         lien: "",
-        variation: 'secondaire'
-      }
-    ],
+    },
     partenaires: []
   },
   'msc': {
@@ -58,18 +50,14 @@ export const proprietesDeVariantsHero = {
       lien: genereImageDePlaceholder(600, 400),
       alt: "Logo placeholder"
     },
-    actions: [
-      {
-        titre: 'Découvrir les services adaptés à NIS2',
-        lien: "",
-        variation: 'primaire'
-      },
-      {
-        titre: "Découvrir le catalogue complet",
-        lien: "",
-        variation: 'secondaire'
-      }
-    ],
+    actionGauche: {
+      titre: 'Découvrir les services adaptés à NIS2',
+      lien: "",
+    },
+    actionDroite: {
+      titre: "Découvrir le catalogue complet",
+      lien: "",
+    },
     partenaires: []
   },
 }


### PR DESCRIPTION
## Pull request de soin sur les retours constatés sur les boutons d'action présents dans la BriqueHero lors de leur intégration dans MAC.

### Au programme : 

- une action est maintenant une balise `<a role="button" ...>` => Plus sémantique par rapport à son usage
- Les deux actions présentes dans la BriqueHero sont distinguée "actionGauche" & "actionDroite" pour permettre une stylisation plus simple
- La petite main au survol des boutons est rajoutée
- Le style des actions au survol change également
- L'icône de succes pour le badge "Service à impact national" est branchée sur la bonne fonction SASS pour s'afficher proprement sur les produits du lab
- Retire le calcul de la largeur sur le composant Brique car elle applique un scroll horizontal indésirable sur les produits

### Captures d'écran : 

MSS :
![image](https://github.com/user-attachments/assets/ee5cc5ff-a372-4fb4-95b1-5b67412351fd)

MAC : 
![image](https://github.com/user-attachments/assets/73c74332-6656-4ad7-a586-913726ef186d)

MSC : 
![image](https://github.com/user-attachments/assets/0628c33e-2a02-4e4f-b5b1-e1e0fa8e9a20)

### Nouvelles variables de thème (8)
`````
    "brique-hero-bouton-gauche-background",
    "brique-hero-bouton-gauche-background-hover",
    "brique-hero-bouton-gauche-background-active",
    "brique-hero-bouton-gauche-texte",
    "brique-hero-bouton-droite-background",
    "brique-hero-bouton-droite-background-hover",
    "brique-hero-bouton-droite-background-active",
    "brique-hero-bouton-droite-texte"
`````