### PR TITLE
Ajoute le composant Alerte en mode information

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@lab-anssi/ui-kit",
-  "version": "1.7.1",
+  "version": "1.8.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@lab-anssi/ui-kit",
-      "version": "1.7.1",
+      "version": "1.8.0",
       "license": "Apache-2.0",
       "devDependencies": {
         "@eslint/compat": "^1.2.5",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@lab-anssi/ui-kit",
-  "version": "1.7.1",
+  "version": "1.8.0",
   "repository": {
     "type": "git",
     "url": "git+https://github.com/betagouv/lab-anssi-ui-kit.git"

--- a/src/lib/Alerte.svelte
+++ b/src/lib/Alerte.svelte
@@ -1,0 +1,44 @@
+<script lang="ts">
+  export let description: string;
+  let estOuvert = true;
+</script>
+
+{#if estOuvert}
+  <div class="alerte">
+    <span class="icone"></span>
+    <div class="contenu">{description}</div>
+    <button
+      class="fermer"
+      on:click={() => {
+        estOuvert = false;
+      }}
+    ></button>
+  </div>
+{/if}
+
+<style lang="scss">
+  .alerte {
+    display: flex;
+    border: 1px solid #0163cb;
+  }
+  .contenu {
+    flex: 1;
+    padding: 8px;
+    color: $texte-secondaire;
+  }
+  .icone {
+    width: 24px;
+    padding: 8px;
+    background: no-repeat center 8px #0163cb url-asset("/icones/information.svg");
+  }
+  .fermer {
+    width: 16px;
+    height: 16px;
+    padding: 8px;
+    margin-top: 4px;
+    margin-right: 4px;
+    background: no-repeat center url-asset("/icones/croix-bleu.svg");
+    border: 0;
+    cursor: pointer;
+  }
+</style>

--- a/src/lib/assets/icones/information.svg
+++ b/src/lib/assets/icones/information.svg
@@ -1,0 +1,3 @@
+<svg width="24" height="24" viewBox="0 0 24 24" fill="none" xmlns="http://www.w3.org/2000/svg">
+<path fill-rule="evenodd" clip-rule="evenodd" d="M19.5 2.5H4.5C3.39543 2.5 2.5 3.39543 2.5 4.5V19.5C2.5 20.6046 3.39543 21.5 4.5 21.5H19.5C20.6046 21.5 21.5 20.6046 21.5 19.5V4.5C21.5 3.39543 20.6046 2.5 19.5 2.5ZM13 7H11V9H13V7ZM13 11H11V17H13V11Z" fill="white"/>
+</svg>

--- a/src/lib/index.ts
+++ b/src/lib/index.ts
@@ -1,8 +1,9 @@
+export { default as Alerte } from "./Alerte.svelte";
 export { default as CentreAide } from "./CentreAide.svelte";
+export { default as ResumePssi } from "./lab/ResumePssi.svelte";
+export { default as BriqueHero } from './lab/vitrines-produits/briques/BriqueHero.svelte';
+export { default as CarrouselTuiles } from './lab/vitrines-produits/briques/CarrouselTuiles.svelte';
 export { default as MesServicesCyberBandeau } from "./mes-services-cyber/bandeau/Bandeau.svelte";
 export { default as LienDiagnosticCyber } from "./mes-services-cyber/lien/LienDiagnosticCyber.svelte";
 export { default as NavigationPiedDePage } from "./pied-de-page/NavigationPiedDePage.svelte";
 export { default as SuiteCyberNavigation } from "./suite-cyber/navigation/Navigation.svelte";
-export { default as ResumePssi } from "./lab/ResumePssi.svelte";
-export { default as BriqueHero } from './lab/vitrines-produits/briques/BriqueHero.svelte'
-export { default as CarrouselTuiles } from './lab/vitrines-produits/briques/CarrouselTuiles.svelte';

--- a/stories/Alerte.story.svelte
+++ b/stories/Alerte.story.svelte
@@ -1,0 +1,21 @@
+<script lang="ts">
+  import Alerte from "$lib/Alerte.svelte";
+  import type { Hst } from "@histoire/plugin-svelte";
+
+  export let Hst: Hst;
+</script>
+
+<Hst.Story title="Composants/Alerte" icon="material-symbols:live-help">
+  <div style="background-color:white; padding:48px;">
+    <h3>Information</h3>
+    <div style="margin: 16px 0;">
+      <Alerte description="Lorem ipsum dolor sit" />
+    </div>
+    <div style="margin: 16px 0;">
+      <Alerte
+        description="
+Lorem ipsum dolor sit amet, consectetur adipiscing elit. Nullam imperdiet laoreet tortor id tristique. Proin vestibulum mi non dui luctus, vitae ornare augue hendrerit."
+      />
+    </div>
+  </div>
+</Hst.Story>


### PR DESCRIPTION
On initie le composant Alerte dans un premier mode "Information" sans titre et avec bouton de fermeture. 

<img width="591" alt="image" src="https://github.com/user-attachments/assets/c34c5db1-c76a-44be-8e10-0a82020b0914" />

https://www.figma.com/design/6zxupO1ivYTw5qxzAyB0XZ/DSFR---Composants---LAB?node-id=1935-417&m=dev
