### PR TITLE
Expose le composant Alerte en tant que webcomponent 

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@lab-anssi/ui-kit",
-  "version": "1.8.0",
+  "version": "1.8.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@lab-anssi/ui-kit",
-      "version": "1.8.0",
+      "version": "1.8.1",
       "license": "Apache-2.0",
       "devDependencies": {
         "@eslint/compat": "^1.2.5",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@lab-anssi/ui-kit",
-  "version": "1.8.0",
+  "version": "1.8.1",
   "repository": {
     "type": "git",
     "url": "git+https://github.com/betagouv/lab-anssi-ui-kit.git"

--- a/src/lib/Alerte.svelte
+++ b/src/lib/Alerte.svelte
@@ -1,3 +1,5 @@
+<svelte:options customElement="lab-anssi-alerte" />
+
 <script lang="ts">
   export let description: string;
   let estOuvert = true;


### PR DESCRIPTION
On souhaite pour importer les composant en tant que WebComponents pour ne pas avoir de contrainte de language/framework dans les applications où ils sont utilisés.

Pour cela il faut bien penser à référencer le composant comme suivant:
`<svelte:options customElement="..."/>`