### PR TITLE
[CORRECTION] Rétablis le déploiement correct du Storybook

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -19,6 +19,7 @@
         "@testing-library/jest-dom": "^6.6.3",
         "@testing-library/svelte": "^5.2.4",
         "@types/node": "^22.13.5",
+        "dotenv": "^16.5.0",
         "eslint": "^9.18.0",
         "eslint-config-prettier": "^10.0.1",
         "eslint-plugin-svelte": "^3.0.0",
@@ -3193,6 +3194,19 @@
       "dependencies": {
         "no-case": "^3.0.4",
         "tslib": "^2.0.3"
+      }
+    },
+    "node_modules/dotenv": {
+      "version": "16.5.0",
+      "resolved": "https://registry.npmjs.org/dotenv/-/dotenv-16.5.0.tgz",
+      "integrity": "sha512-m/C+AwOAr9/W1UOIZUo232ejMNnJAJtYQjUbHoNTBNTJSvqzzDh7vnrei3o3r3m9blf6ZoDkvcw0VmozNRFJxg==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://dotenvx.com"
       }
     },
     "node_modules/dunder-proto": {

--- a/package.json
+++ b/package.json
@@ -16,8 +16,8 @@
     "build:webcomponents": "vite -c vite.webcomponents.config.ts build",
     "prepare": "svelte-kit sync || echo ''",
     "prepack": "svelte-kit sync && svelte-package && npm run build:webcomponents && publint",
-    "story:dev": "histoire dev",
-    "story:build": "histoire build",
+    "story:dev": "HISTOIRE_ENV=development histoire dev",
+    "story:build": "HISTOIRE_ENV=production histoire build",
     "test": "vitest"
   },
   "files": [
@@ -55,6 +55,7 @@
     "@testing-library/jest-dom": "^6.6.3",
     "@testing-library/svelte": "^5.2.4",
     "@types/node": "^22.13.5",
+    "dotenv": "^16.5.0",
     "eslint": "^9.18.0",
     "eslint-config-prettier": "^10.0.1",
     "eslint-plugin-svelte": "^3.0.0",

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -1,9 +1,20 @@
 import { sveltekit } from "@sveltejs/kit/vite";
 import { loadEnv } from "vite";
 import { defineConfig } from "vitest/config";
+import dotenv from 'dotenv';
+import { resolve } from 'path'
 
-// On ne build jamais pour le local : allons chercher en dur les variables de PROD.
-const varEnvDeProduction = loadEnv("production", process.cwd(), "VITE_");
+// Charge le bon environnement pour faire fonctionner la méthode SCSS `url-asset`
+// - Build webcomponent : "production"
+// - Storybook local : "development"
+// - Storybook déployé : "production"
+const varEnv = loadEnv(process.env.HISTOIRE_ENV ?? "production", process.cwd(), "VITE_");
+
+// On charge manuellement les valeurs d'environnement de la production, car pour une raison qu'on ignore
+// c'est la seule façon de charger Histoire avec nos valeurs
+// Cela permet de faire fonctionner la méthode JS `srcAsset` dans le cas du Storybook déployé
+if(process.env.HISTOIRE_ENV === 'production')
+  dotenv.config({ path: resolve(process.cwd(), '.env.production') })
 
 export default defineConfig({
   plugins: [sveltekit()],
@@ -18,7 +29,7 @@ export default defineConfig({
           @use 'src/variables.scss' as *; 
           @use 'src/responsive.scss' as *; 
           @use 'src/assets.scss' as *;
-          $assets-url-base: '${varEnvDeProduction.VITE_LAB_ANSSI_UI_KIT_ASSET_BASE}'; 
+          $assets-url-base: '${varEnv.VITE_LAB_ANSSI_UI_KIT_ASSET_BASE}'; 
         `,
       },
     },


### PR DESCRIPTION
... En utilisant le bon fichier `.env` en fonction du mode pour `Histoire`, car par défaut, `histoire build` lance le fichier `vite.config` en mode `development`.

On s'assure donc que :
- Pour le BUILD : toujours en production
- Pour le DEV Histoire : en mode dev
- Pour le BUILD Histoire : en mode production