### PR TITLE
[COMPOSANT] Brique réutilisable à deux colonnes

### DIFF
--- a/src/lib/index.ts
+++ b/src/lib/index.ts
@@ -9,3 +9,4 @@ export { default as NavigationPiedDePage } from "./pied-de-page/NavigationPiedDe
 export { default as SuiteCyberNavigation } from "./suite-cyber/navigation/Navigation.svelte";
 export { default as BriqueTitreMultimedia } from "./lab/vitrines-produits/briques/BriqueTitreMultimedia.svelte";
 export { default as Marelle } from "./lab/vitrines-produits/briques/marelle/Marelle.svelte";
+export { default as BriqueContenuADeuxColonnes } from "./lab/vitrines-produits/briques/BriqueContenuADeuxColonnes.svelte";

--- a/src/lib/lab/vitrines-produits/briques/BriqueContenuADeuxColonnes.svelte
+++ b/src/lib/lab/vitrines-produits/briques/BriqueContenuADeuxColonnes.svelte
@@ -1,0 +1,134 @@
+
+
+<script lang="ts">
+  import Brique from "$lib/lab/vitrines-produits/briques/Brique.svelte";
+  import type { Action, Image } from "$lib/types";
+
+  export let titre: string;
+  export let paragraphe: string;
+  export let action: Action | undefined;
+
+  export let illustration: Image;
+</script>
+
+<Brique variation="primaire">
+  <div class="grille-contenu">
+    <div class="illustration">
+      <img src={illustration.lien} alt={illustration.alt} />
+    </div>
+    <div class="contenu">
+      <h2>{titre}</h2>
+      <p>{paragraphe}</p>
+      <div class="action">
+        {#if action}
+          <a role="button" href={action.lien} target="_blank">
+            {action.titre}
+          </a>
+        {/if}
+      </div>
+    </div>
+  </div>
+</Brique>
+
+<style lang="scss">
+  .grille-contenu {
+    display: grid;
+    grid-template-columns: 1fr;
+    grid-template-areas: 'illustration'
+                          'contenu';
+    gap: 32px;
+
+    @include a-partir-de(desktop) {
+      grid-template-columns: 1fr 1fr;
+      grid-template-areas: 'contenu illustration';
+      column-gap: 24px;
+    }
+
+    .contenu {
+      grid-area: contenu;
+      display: flex;
+      flex-direction: column;
+      row-gap: 8px;
+
+      @include a-partir-de(desktop) {
+        justify-content: center;
+      }
+
+      h2 {
+        font-size: 1.75rem;
+        line-height: 2.25rem;
+        font-weight: 700;
+        word-break: break-word;
+
+        margin: 0;
+      }
+
+      p {
+        font-size: 1rem;
+        font-weight: 400;
+        line-height: 1.5rem;
+
+        margin: 0;
+      }
+
+      .action {
+        a[role='button'] {
+          display: flex;
+          justify-content: center;
+          text-decoration: none;
+          font-family: Marianne, sans-serif;
+          padding: 8px 16px;
+          max-width: 100%;
+
+          text-align: center;
+          font-weight: 500;
+          font-size: 1rem;
+          line-height: 24px;
+
+          border-radius: 4px;
+
+          background-color: $brique-contenu-deux-colonnes-action-bouton-background;
+          color: $brique-contenu-deux-colonnes-action-bouton-texte;
+          border: none;
+          cursor: pointer;
+
+          &:active {
+            background-color: $brique-contenu-deux-colonnes-action-bouton-background-active;
+            box-shadow: none;
+            border: none;
+          }
+
+          &:hover {
+            background-color: $brique-contenu-deux-colonnes-action-bouton-background-hover;
+            box-shadow: none;
+            border: none;
+          }
+
+          @include a-partir-de(tablette) {
+            max-width: unset;
+            width: fit-content;
+          }
+        }
+
+        margin-top: 32px;
+      }
+    }
+
+    .illustration {
+      grid-area: illustration;
+      img {
+        width: 100%;
+        max-height: 250px;
+
+        @include a-partir-de(tablette) {
+          max-height: none;
+        }
+
+        @include a-partir-de(desktop) {
+          max-height: 330px;
+        }
+      }
+    }
+
+  }
+</style>

--- a/src/lib/lab/vitrines-produits/briques/BriqueContenuADeuxColonnes.svelte
+++ b/src/lib/lab/vitrines-produits/briques/BriqueContenuADeuxColonnes.svelte
@@ -7,12 +7,13 @@
   export let titre: string;
   export let paragraphe: string;
   export let action: Action | undefined;
+  export let ordre: 'texte-gauche' | 'texte-droite' = 'texte-gauche';
 
   export let illustration: Image;
 </script>
 
 <Brique variation="primaire">
-  <div class="grille-contenu">
+  <div class={`grille-contenu ${ordre}`}>
     <div class="illustration">
       <img src={illustration.lien} alt={illustration.alt} />
     </div>
@@ -42,6 +43,14 @@
       grid-template-columns: 1fr 1fr;
       grid-template-areas: 'contenu illustration';
       column-gap: 24px;
+
+      &.texte-gauche {
+        grid-template-areas: 'contenu illustration';
+      }
+
+      &.texte-droite {
+        grid-template-areas: 'illustration contenu';
+      }
     }
 
     .contenu {

--- a/src/lib/lab/vitrines-produits/briques/BriqueContenuADeuxColonnes.svelte
+++ b/src/lib/lab/vitrines-produits/briques/BriqueContenuADeuxColonnes.svelte
@@ -1,4 +1,14 @@
-
+<svelte:options
+  customElement={{
+		tag: 'lab-anssi-brique-contenu-a-deux-colonnes',
+		props: {
+      titre: { reflect: false, type: 'String', attribute: 'titre' },
+      paragraphe: { reflect: false, type: 'String', attribute: 'paragraphe' },
+			action: { reflect: false, type: 'Object', attribute: 'action' },
+      ordre: { reflect: false, type: 'String', attribute: 'ordre' },
+      illustration: { reflect: false, type: 'Object', attribute: 'illustration' }
+		}
+	}} />
 
 <script lang="ts">
   import Brique from "$lib/lab/vitrines-produits/briques/Brique.svelte";
@@ -6,7 +16,7 @@
 
   export let titre: string;
   export let paragraphe: string;
-  export let action: Action | undefined;
+  export let action: Action | undefined = undefined;
   export let ordre: 'texte-gauche' | 'texte-droite' = 'texte-gauche';
 
   export let illustration: Image;

--- a/src/variables.scss
+++ b/src/variables.scss
@@ -56,6 +56,13 @@ $brique-marelle-bouton-texte: var(--brique-marelle-bouton-texte);
 $brique-temoignages-titre-couleur: var(--brique-temoignages-titre-couleur);
 $brique-temoignages-icone-couleur: var(--brique-temoignages-icone-couleur);
 
+// - Brique de contenu à deux colonnes
+
+$brique-contenu-deux-colonnes-action-bouton-background: var(--brique-contenu-deux-colonnes-action-bouton-background);
+$brique-contenu-deux-colonnes-action-bouton-background-hover: var(--brique-contenu-deux-colonnes-action-bouton-background-hover);
+$brique-contenu-deux-colonnes-action-bouton-background-active: var(--brique-contenu-deux-colonnes-action-bouton-background-active);
+$brique-contenu-deux-colonnes-action-bouton-texte: var(--brique-contenu-deux-colonnes-action-bouton-texte);
+
 // Affichage
 $z-index-au-dessus: 1000;
 

--- a/stories/OutilSelecteurTheme.svelte
+++ b/stories/OutilSelecteurTheme.svelte
@@ -29,7 +29,11 @@
     "brique-marelle-bouton-background-active",
     "brique-marelle-bouton-texte",
     "brique-temoignages-titre-couleur",
-    "brique-temoignages-icone-couleur"
+    "brique-temoignages-icone-couleur",
+    "brique-contenu-deux-colonnes-action-bouton-background",
+    "brique-contenu-deux-colonnes-action-bouton-background-hover",
+    "brique-contenu-deux-colonnes-action-bouton-background-active",
+    "brique-contenu-deux-colonnes-action-bouton-texte",
   ] as const;
   type VariablesCSS = (typeof variablesCSS)[number];
 
@@ -63,7 +67,11 @@
       "brique-marelle-bouton-background-active": "#0279D0",
       "brique-marelle-bouton-texte": "#FFFFFF",
       "brique-temoignages-titre-couleur": "#09416A",
-      "brique-temoignages-icone-couleur": "#0279D0"
+      "brique-temoignages-icone-couleur": "#0279D0",
+      "brique-contenu-deux-colonnes-action-bouton-background": "#FFFFFF",
+      "brique-contenu-deux-colonnes-action-bouton-background-hover": "#F6F6F6",
+      "brique-contenu-deux-colonnes-action-bouton-background-active": "#F6F6F6",
+      "brique-contenu-deux-colonnes-action-bouton-texte": "#0279D0"
     },
     MonAideCyber: {
       "centre-aide-background-entete": "#5D2A9D",
@@ -92,7 +100,11 @@
       "brique-marelle-bouton-background-active": "#9C51D0",
       "brique-marelle-bouton-texte": "#FFFFFF",
       "brique-temoignages-titre-couleur": "#5D2A9D",
-      "brique-temoignages-icone-couleur": "#9C51D0"
+      "brique-temoignages-icone-couleur": "#9C51D0",
+      "brique-contenu-deux-colonnes-action-bouton-background": "white",
+      "brique-contenu-deux-colonnes-action-bouton-background-hover": "#F6F6F6",
+      "brique-contenu-deux-colonnes-action-bouton-background-active": "#F6F6F6",
+      "brique-contenu-deux-colonnes-action-bouton-texte": "#5D2A9D"
     },
     MesServicesCyber: {
       "centre-aide-background-entete": '#0d0c21 url("src/lib/assets/illustrations/tuile-msc.svg") repeat top left / 500px',
@@ -121,7 +133,11 @@
       "brique-marelle-bouton-background-active": "#DDBD70",
       "brique-marelle-bouton-texte": "#0D0C21",
       "brique-temoignages-titre-couleur": "#0D0C21",
-      "brique-temoignages-icone-couleur": "#FED980"
+      "brique-temoignages-icone-couleur": "#FED980",
+      "brique-contenu-deux-colonnes-action-bouton-background": "#FED980",
+      "brique-contenu-deux-colonnes-action-bouton-background-hover": "#ECCA79",
+      "brique-contenu-deux-colonnes-action-bouton-background-active": "#DDBD70",
+      "brique-contenu-deux-colonnes-action-bouton-texte": "#0D0C21"
     },
     MonEspaceNIS2: {
       "centre-aide-background-entete": "#272771",
@@ -150,7 +166,11 @@
       "brique-marelle-bouton-background-active": "#41419F",
       "brique-marelle-bouton-texte": "#FFFFFF",
       "brique-temoignages-titre-couleur": "#272771",
-      "brique-temoignages-icone-couleur": "#41419F"
+      "brique-temoignages-icone-couleur": "#41419F",
+      "brique-contenu-deux-colonnes-action-bouton-background": "#FFFFFF",
+      "brique-contenu-deux-colonnes-action-bouton-background-hover": "#FFFFFF",
+      "brique-contenu-deux-colonnes-action-bouton-background-active": "#FFFFFF",
+      "brique-contenu-deux-colonnes-action-bouton-texte": "#272771"
     },
   };
 

--- a/stories/exemples-integration/LandingMAC.story.svelte
+++ b/stories/exemples-integration/LandingMAC.story.svelte
@@ -8,6 +8,7 @@
   import { BriqueTitreMultimedia } from "$lib";
   import Marelle from "$lib/lab/vitrines-produits/briques/marelle/Marelle.svelte";
   import Temoignages from "$lib/lab/vitrines-produits/briques/temoignages/Temoignages.svelte";
+  import BriqueContenuADeuxColonnes from "$lib/lab/vitrines-produits/briques/BriqueContenuADeuxColonnes.svelte";
 
   export let Hst: Hst;
 
@@ -105,4 +106,10 @@
         source: 'Un Aidant cyber, réserviste de la Police, dans le Rhône (69)'
       }
     ]}/>
+  <BriqueContenuADeuxColonnes titre="Rejoignez la communauté des Aidants cyber !"
+                              paragraphe="En tant que membre de la communauté, vous pourrez : <br /> - Echanger directement avec les autres Aidants cyber <br /> - Participer activement au développement du diagnostic cyber en nous partageant vos besoins et suggestions d'amélioration."
+                              action={{ titre: 'Rejoindre la communauté', lien: '#', }}
+                              ordre="texte-droite"
+                              illustration={{ lien: genereImageDePlaceholder(600, 400, "Image de substitution"), alt: ''}}
+  ></BriqueContenuADeuxColonnes>
 </Hst.Story>

--- a/stories/lab/vitrines-produits/briques/BriqueContenuADeuxColonnes.story.svelte
+++ b/stories/lab/vitrines-produits/briques/BriqueContenuADeuxColonnes.story.svelte
@@ -10,16 +10,18 @@
   let paragraphe = "L'outil pour piloter en équipe la sécurité de tous vos services numériques et les homologuer rapidement";
   let illustration = { lien: genereImageDePlaceholder(600, 400, 'Placeholder'), alt: "Logo placeholder" };
   let action = { titre: "Commencer à sécuriser", lien: "#" };
+  let ordre: 'texte-gauche' | 'texte-droite' = 'texte-gauche'
 </script>
 
 <Hst.Story title="Composants/Lab/Sites vitrines/Brique Contenu à deux colonnes" icon="material-symbols:brick-outline">
   <OutilSelecteurTheme themeSelectionne="MonServiceSécurisé" />
-  <BriqueContenuADeuxColonnes {titre} {paragraphe} {illustration} {action} />
+  <BriqueContenuADeuxColonnes {titre} {paragraphe} {illustration} {action} {ordre} />
 
   <svelte:fragment slot="controls">
+    <Hst.Text title="Ordre des éléments" bind:value={ordre} />
     <Hst.Text title="Titre" bind:value={titre} />
     <Hst.Text title="Texte" bind:value={paragraphe} />
     <Hst.Json title="Illustration" bind:value={illustration} />
-    <Hst.Json title="Action" bind:value={action} />
+    <Hst.Json title="Action (texte-gauche ou texte-droite)" bind:value={action} />
   </svelte:fragment>
 </Hst.Story>

--- a/stories/lab/vitrines-produits/briques/BriqueContenuADeuxColonnes.story.svelte
+++ b/stories/lab/vitrines-produits/briques/BriqueContenuADeuxColonnes.story.svelte
@@ -9,8 +9,20 @@
   let titre = "Mon​Service​Sécurisé";
   let paragraphe = "L'outil pour piloter en équipe la sécurité de tous vos services numériques et les homologuer rapidement";
   let illustration = { lien: genereImageDePlaceholder(600, 400, 'Placeholder'), alt: "Logo placeholder" };
-  let action = { titre: "Commencer à sécuriser", lien: "#" };
-  let ordre: 'texte-gauche' | 'texte-droite' = 'texte-gauche'
+  let comporteUneAction = false;
+  let action: { titre: string; lien: string } | undefined;
+  $: action = comporteUneAction ? { titre: "Commencer à sécuriser", lien: "#" } : undefined;
+
+  let ordre: 'texte-gauche' | 'texte-droite' = 'texte-gauche';
+
+  const options = [
+    {
+      value: "texte-gauche", label: "Contenu à gauche",
+    },
+    {
+      value: "texte-droite", label: "Contenu à droite",
+    }
+  ]
 </script>
 
 <Hst.Story title="Composants/Lab/Sites vitrines/Brique Contenu à deux colonnes" icon="material-symbols:brick-outline">
@@ -18,10 +30,13 @@
   <BriqueContenuADeuxColonnes {titre} {paragraphe} {illustration} {action} {ordre} />
 
   <svelte:fragment slot="controls">
-    <Hst.Text title="Ordre des éléments" bind:value={ordre} />
+    <Hst.Select title="Position du contenu" {options} bind:value={ordre} />
     <Hst.Text title="Titre" bind:value={titre} />
     <Hst.Text title="Texte" bind:value={paragraphe} />
+    <Hst.Checkbox title="Comporte une action ?" bind:value={comporteUneAction}/>
+    {#if comporteUneAction}
+      <Hst.Json title="Action" bind:value={action} />
+    {/if}
     <Hst.Json title="Illustration" bind:value={illustration} />
-    <Hst.Json title="Action (texte-gauche ou texte-droite)" bind:value={action} />
   </svelte:fragment>
 </Hst.Story>

--- a/stories/lab/vitrines-produits/briques/BriqueContenuADeuxColonnes.story.svelte
+++ b/stories/lab/vitrines-produits/briques/BriqueContenuADeuxColonnes.story.svelte
@@ -1,0 +1,25 @@
+<script lang="ts">
+  import type { Hst } from "@histoire/plugin-svelte";
+  import OutilSelecteurTheme from "../../../OutilSelecteurTheme.svelte";
+  import { genereImageDePlaceholder } from "$lib/generateurImagesPlaceholders";
+  import BriqueContenuADeuxColonnes from "$lib/lab/vitrines-produits/briques/BriqueContenuADeuxColonnes.svelte";
+
+  export let Hst: Hst;
+
+  let titre = "Mon​Service​Sécurisé";
+  let paragraphe = "L'outil pour piloter en équipe la sécurité de tous vos services numériques et les homologuer rapidement";
+  let illustration = { lien: genereImageDePlaceholder(600, 400, 'Placeholder'), alt: "Logo placeholder" };
+  let action = { titre: "Commencer à sécuriser", lien: "#" };
+</script>
+
+<Hst.Story title="Composants/Lab/Sites vitrines/Brique Contenu à deux colonnes" icon="material-symbols:brick-outline">
+  <OutilSelecteurTheme themeSelectionne="MonServiceSécurisé" />
+  <BriqueContenuADeuxColonnes {titre} {paragraphe} {illustration} {action} />
+
+  <svelte:fragment slot="controls">
+    <Hst.Text title="Titre" bind:value={titre} />
+    <Hst.Text title="Texte" bind:value={paragraphe} />
+    <Hst.Json title="Illustration" bind:value={illustration} />
+    <Hst.Json title="Action" bind:value={action} />
+  </svelte:fragment>
+</Hst.Story>


### PR DESCRIPTION
Ajoute la brique de contenu à deux colonnes.

![image](https://github.com/user-attachments/assets/a1d36377-f43a-48fa-8293-f5b08df67f9b)
![image](https://github.com/user-attachments/assets/b5ebb369-0fec-4742-a433-56c640117fdf)

Le contenu de cette brique peut être réordonné (illustration à gauche, textes à droite OU vice versa)
