### PR TITLE
Corrige les largeurs de l’alerte

### DIFF
--- a/src/lib/Alerte.svelte
+++ b/src/lib/Alerte.svelte
@@ -22,6 +22,7 @@
   .alerte {
     display: flex;
     border: 1px solid #0163cb;
+    min-width: 200px;
   }
   .contenu {
     flex: 1;
@@ -29,8 +30,8 @@
     color: $texte-secondaire;
   }
   .icone {
-    width: 24px;
-    padding: 8px;
+    width: 40px;
+    min-width: 40px;
     background: no-repeat center 8px #0163cb url-asset("/icones/information.svg");
   }
   .fermer {


### PR DESCRIPTION
D’une part, la largeur autour de l’icône est corrigée pour toujours rester à 40px. D’autre part, on force l’alerte à ne jamais se réduire sous 200px.

![image](https://github.com/user-attachments/assets/93e5251e-a7c5-4b81-908b-d0f88773f62f)
