### PR TITLE
Cache le marqueur du sommaire sur safari

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@lab-anssi/ui-kit",
-  "version": "1.14.0",
+  "version": "1.14.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@lab-anssi/ui-kit",
-      "version": "1.14.0",
+      "version": "1.14.1",
       "license": "Apache-2.0",
       "devDependencies": {
         "@eslint/compat": "^1.2.5",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@lab-anssi/ui-kit",
-  "version": "1.14.0",
+  "version": "1.14.1",
   "repository": {
     "type": "git",
     "url": "git+https://github.com/betagouv/lab-anssi-ui-kit.git"

--- a/src/lib/lab/blog/SommaireMobile.svelte
+++ b/src/lib/lab/blog/SommaireMobile.svelte
@@ -120,6 +120,7 @@
       }
 
       summary {
+        list-style: none;
         &::marker {
           content: "";
         }


### PR DESCRIPTION
Le marqueur doit être caché avec un `list-style:none` sur Safari depuis la version 18. 