### PR TITLE
[CORRECTION] Empêche le rétrécissement des icônes du sommaire mobile

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@lab-anssi/ui-kit",
-  "version": "1.14.1",
+  "version": "1.14.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@lab-anssi/ui-kit",
-      "version": "1.14.1",
+      "version": "1.14.2",
       "license": "Apache-2.0",
       "devDependencies": {
         "@eslint/compat": "^1.2.5",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@lab-anssi/ui-kit",
-  "version": "1.14.1",
+  "version": "1.14.2",
   "repository": {
     "type": "git",
     "url": "git+https://github.com/betagouv/lab-anssi-ui-kit.git"

--- a/src/lib/lab/blog/IconeChevronBas.svelte
+++ b/src/lib/lab/blog/IconeChevronBas.svelte
@@ -15,7 +15,11 @@
 </svg>
 
 <style lang="scss">
-  path {
-    fill: $sommaire-actif-couleur;
+  svg {
+    flex-shrink: 0;
+
+    path {
+      fill: $sommaire-actif-couleur;
+    }
   }
 </style>

--- a/src/lib/lab/blog/IconeMenuLateral.svelte
+++ b/src/lib/lab/blog/IconeMenuLateral.svelte
@@ -8,7 +8,11 @@
 </svg>
 
 <style lang="scss">
-  path {
-    fill: $sommaire-actif-couleur;
+  svg {
+    flex-shrink: 0;
+
+    path {
+      fill: $sommaire-actif-couleur;
+    }
   }
 </style>


### PR DESCRIPTION
... car ils peuvent être réduit si le titre du sommaire est long.