### PR TITLE
[CI] Installe Playwright avant l'execution des tests

### DIFF
--- a/.github/workflows/publication-npm.yml
+++ b/.github/workflows/publication-npm.yml
@@ -26,6 +26,9 @@ jobs:
       - name: Installer les dépendances
         run: npm ci
 
+      - name: Installer Playwright
+        run: npx playwright install --with-deps
+
       - name: Exécuter les tests
         run: npm run test
 

--- a/.github/workflows/publication-storybook-dev.yml
+++ b/.github/workflows/publication-storybook-dev.yml
@@ -20,6 +20,9 @@ jobs:
       - name: Installer les dépendances
         run: npm ci
 
+      - name: Installer Playwright
+        run: npx playwright install --with-deps
+
       - name: Exécuter les tests
         run: npm run test
 

--- a/.github/workflows/publication-storybook.yml
+++ b/.github/workflows/publication-storybook.yml
@@ -22,6 +22,9 @@ jobs:
       - name: Installer les dépendances
         run: npm ci
 
+      - name: Installer Playwright
+        run: npx playwright install --with-deps
+
       - name: Exécuter les tests
         run: npm run test
 


### PR DESCRIPTION
En raison de l'utilisation de **Playwright** par Storybook, nous devons setup Playwright avant de lancer la commande de test.
Cette PR ajoute donc une étape qui effectue cela dans chacune des GitHub Actions qui effectue de l'exécution de tests.