### PR TITLE
Migration des composants "Lab" en Svelte 5

### DIFF
--- a/src/lib/lab/Bouton.svelte
+++ b/src/lib/lab/Bouton.svelte
@@ -16,13 +16,25 @@
 <script lang="ts">
   import Icone from "$lib/lab/Icone.svelte";
 
-  export let titre: string;
-  export let variante: "primaire" | "secondaire" | "tertiaire" | "tertiaire-sans-bordure";
-  export let taille: "sm" | "md" | "lg";
-  export let icone: string | undefined = undefined;
-  export let positionIcone: "sans" | "seule" | "droite" | "gauche" = "sans";
-  export let actif: boolean = true;
-  export let largeurMaximale: boolean = false;
+  interface Props {
+    titre: string;
+    variante: "primaire" | "tertiaire" | "tertiaire-sans-bordure";
+    taille: "sm" | "md" | "lg";
+    icone?: string | undefined;
+    positionIcone?: "sans" | "seule" | "droite" | "gauche";
+    actif?: boolean;
+    largeurMaximale?: boolean;
+  }
+
+  let {
+    titre,
+    variante,
+    taille,
+    icone = undefined,
+    positionIcone = "sans",
+    actif = true,
+    largeurMaximale = false,
+  }: Props = $props();
 </script>
 
 <button

--- a/src/lib/lab/Icone.svelte
+++ b/src/lib/lab/Icone.svelte
@@ -9,8 +9,12 @@
 />
 
 <script lang="ts">
-  export let nom: string;
-  export let taille: "sm" | "md" | "lg" | undefined = undefined;
+  interface Props {
+    nom: string;
+    taille?: "sm" | "md" | "lg" | undefined;
+  }
+
+  let { nom, taille = undefined }: Props = $props();
 </script>
 
 <span class="icone fr-icon-{nom} {taille}"></span>

--- a/src/lib/lab/Lien.svelte
+++ b/src/lib/lab/Lien.svelte
@@ -19,16 +19,31 @@
 <script lang="ts">
   import Icone from "$lib/lab/Icone.svelte";
 
-  export let titre: string;
-  export let href: string;
-  export let variante: "primaire" | "secondaire" | "tertiaire" | "tertiaire-sans-bordure";
-  export let taille: "sm" | "md" | "lg";
-  export let icone: string | undefined = undefined;
-  export let apparence: "lien" | "bouton" | "lien-texte" = "lien";
-  export let cible: string | undefined = undefined;
-  export let positionIcone: "sans" | "seule" | "droite" | "gauche" = "sans";
-  export let actif: boolean = true;
-  export let largeurMaximale: boolean = false;
+  interface Props {
+    titre: string;
+    href: string;
+    variante: "primaire" | "tertiaire" | "tertiaire-sans-bordure";
+    taille: "sm" | "md" | "lg";
+    icone?: string | undefined;
+    apparence?: "lien" | "bouton" | "lien-texte";
+    cible?: string | undefined;
+    positionIcone?: "sans" | "seule" | "droite" | "gauche";
+    actif?: boolean;
+    largeurMaximale?: boolean;
+  }
+
+  let {
+    titre,
+    href,
+    variante,
+    taille,
+    icone = undefined,
+    apparence = "lien",
+    cible = undefined,
+    positionIcone = "sans",
+    actif = true,
+    largeurMaximale = false,
+  }: Props = $props();
 </script>
 
 <a

--- a/src/lib/lab/ResumePssi.svelte
+++ b/src/lib/lab/ResumePssi.svelte
@@ -1,7 +1,11 @@
 <svelte:options customElement="lab-anssi-resume-pssi" />
 
 <script lang="ts">
-  export let nomService: string;
+  interface Props {
+    nomService: string;
+  }
+
+  let { nomService }: Props = $props();
 </script>
 
 <p>

--- a/src/lib/lab/Tag.svelte
+++ b/src/lib/lab/Tag.svelte
@@ -13,13 +13,24 @@
 />
 
 <script lang="ts">
-  export let label: string;
-  export let couleurTexte: string | undefined;
-  export let couleurFond: string | undefined;
-  export let taille: "sm" | "md" = "sm";
-  export let type: "defaut" | "selectionnable" = "defaut";
-  export let presse: boolean = false;
-  $: selectionne = presse;
+  interface Props {
+    label: string;
+    couleurTexte: string | undefined;
+    couleurFond: string | undefined;
+    taille?: "sm" | "md";
+    type?: "defaut" | "selectionnable";
+    presse?: boolean;
+  }
+
+  let {
+    label,
+    couleurTexte,
+    couleurFond,
+    taille = "sm",
+    type = "defaut",
+    presse = false,
+  }: Props = $props();
+  let selectionne = $derived(presse);
 
   const bascule = () => {
     selectionne = !selectionne;
@@ -36,7 +47,7 @@
     aria-pressed={selectionne}
     style:background={couleurFond}
     style:color={couleurTexte}
-    on:click={bascule}
+    onclick={bascule}
   >
     {label}
   </button>


### PR DESCRIPTION
Cette PR effectue l'ensemble des évolutions de code permettant de passer de Svelte 4 à Svelte 5, pour les composants suivants :

- Composant **Bouton**
- Composant **Icone**
- Composant **Lien**
- Composant **ResumePssi**
- Composant **Tag**