### PR TITLE
Migration des composants "Blog" en Svelte 5

### DIFF
--- a/src/lib/lab/blog/BandeauTitre.svelte
+++ b/src/lib/lab/blog/BandeauTitre.svelte
@@ -14,12 +14,16 @@
   import { estLien, type NoeudFilAriane, type InfosTag } from "$lib/types.js";
   import Tag from "$lib/lab/Tag.svelte";
 
-  export let titre: string;
-  export let description: string = "";
-  export let filAriane: NoeudFilAriane[] = [];
-  export let infosTag: InfosTag | null = null;
+  interface Props {
+    titre: string;
+    description?: string;
+    filAriane?: NoeudFilAriane[];
+    infosTag?: InfosTag | null;
+  }
 
-  let filArianeVisible = window.matchMedia("(min-width: 576px)").matches;
+  let { titre, description = "", filAriane = [], infosTag = null }: Props = $props();
+
+  let filArianeVisible = $state(window.matchMedia("(min-width: 576px)").matches);
 </script>
 
 <div class="conteneur-bandeau-entete">
@@ -27,7 +31,7 @@
     {#if filAriane.length}
       <div class="fil-ariane">
         {#if !filArianeVisible}
-          <button on:click={() => (filArianeVisible = true)}>Voir le fil d'Ariane</button>
+          <button onclick={() => (filArianeVisible = true)}>Voir le fil d'Ariane</button>
         {:else}
           {#each filAriane as noeud, index (index)}
             {#if estLien(noeud)}

--- a/src/lib/lab/blog/CarteArticle.svelte
+++ b/src/lib/lab/blog/CarteArticle.svelte
@@ -3,8 +3,12 @@
   import Tag from "$lib/lab/Tag.svelte";
   import Fleche from "$lib/lab/icones/Fleche.svelte";
 
-  export let article: ResumeArticle;
-  export let categorie: InfosTag;
+  interface Props {
+    article: ResumeArticle;
+    categorie: InfosTag;
+  }
+
+  let { article, categorie }: Props = $props();
 </script>
 
 <a class="carte-article" href={article.href}>

--- a/src/lib/lab/blog/ListeArticles.svelte
+++ b/src/lib/lab/blog/ListeArticles.svelte
@@ -14,9 +14,13 @@
   import CarteArticle from "$lib/lab/blog/CarteArticle.svelte";
   import ListeDeroulante from "$lib/lab/blog/ListeDeroulante.svelte";
 
-  export let articles: ResumeArticle[];
-  export let categories: CategoriesArticle;
-  export let idCategorieChoisie: string = "tous";
+  interface Props {
+    articles: ResumeArticle[];
+    categories: CategoriesArticle;
+    idCategorieChoisie?: string;
+  }
+
+  let { articles, categories, idCategorieChoisie = $bindable("tous") }: Props = $props();
 
   const optionsFiltrage = [
     { label: "Tous les articles", valeur: "tous" },
@@ -26,10 +30,11 @@
     })),
   ];
 
-  $: articlesVisibles =
+  let articlesVisibles = $derived(
     idCategorieChoisie === "tous"
       ? articles
-      : articles.filter((a) => a.idCategorie === idCategorieChoisie);
+      : articles.filter((a) => a.idCategorie === idCategorieChoisie),
+  );
 </script>
 
 <div class="liste-articles">

--- a/src/lib/lab/blog/ListeDeroulante.svelte
+++ b/src/lib/lab/blog/ListeDeroulante.svelte
@@ -1,8 +1,12 @@
 <script lang="ts">
   import { srcAsset } from "$lib/assets/assets";
 
-  export let valeur: string;
-  export let options: { label: string; valeur: unknown }[];
+  interface Props {
+    valeur: string;
+    options: { label: string; valeur: unknown }[];
+  }
+
+  let { valeur = $bindable(), options }: Props = $props();
 </script>
 
 <div class="conteneur-liste-deroulante">
@@ -13,7 +17,7 @@
     />
     <select bind:value={valeur}>
       {#each options as option, index (index)}
-        <option label={option.label} value={option.valeur} />
+        <option label={option.label} value={option.valeur}></option>
       {/each}
     </select>
   </div>

--- a/src/lib/lab/blog/PageCrisp.svelte
+++ b/src/lib/lab/blog/PageCrisp.svelte
@@ -9,15 +9,21 @@
 />
 
 <script lang="ts">
+  import { run } from "svelte/legacy";
+
   import type { TableDesMatieres } from "$lib/types";
   import SommaireMobile from "$lib/lab/blog/SommaireMobile.svelte";
   import { onDestroy, tick } from "svelte";
   import SommaireBureau from "$lib/lab/blog/SommaireBureau.svelte";
 
-  export let contenu: string;
-  export let tableDesMatieres: TableDesMatieres;
+  interface Props {
+    contenu: string;
+    tableDesMatieres: TableDesMatieres;
+  }
 
-  let composant: HTMLDivElement;
+  let { contenu, tableDesMatieres }: Props = $props();
+
+  let composant: HTMLDivElement = $state();
   let observateurDIntersection: IntersectionObserver;
 
   const observeLesSections = () => {
@@ -46,7 +52,9 @@
     lesSections.forEach((s) => observateurDIntersection.observe(s));
   };
 
-  $: if (contenu) tick().then(observeLesSections);
+  run(() => {
+    if (contenu) tick().then(observeLesSections);
+  });
 
   const attendChargementImages = async () => {
     const images = composant.querySelectorAll("img");
@@ -73,7 +81,9 @@
     }
   };
 
-  $: if (contenu) scroll(window.location.hash);
+  run(() => {
+    if (contenu) scroll(window.location.hash);
+  });
 
   const ancreOuverte = (evenement: CustomEvent) => scroll(`#${evenement.detail}`);
 

--- a/src/lib/lab/blog/SommaireBureau.svelte
+++ b/src/lib/lab/blog/SommaireBureau.svelte
@@ -2,7 +2,11 @@
   import type { TableDesMatieres } from "$lib/types";
   import { createEventDispatcher } from "svelte";
 
-  export let tableDesMatieres: TableDesMatieres;
+  interface Props {
+    tableDesMatieres: TableDesMatieres;
+  }
+
+  let { tableDesMatieres }: Props = $props();
 
   const emets = createEventDispatcher<{
     ancreOuverte: string;
@@ -17,7 +21,7 @@
   <ul>
     {#each tableDesMatieres as entree (entree.id)}
       <li>
-        <a href={`#${entree.id}`} on:click={() => ouvreEntree(entree.id)}>
+        <a href={`#${entree.id}`} onclick={() => ouvreEntree(entree.id)}>
           <!-- eslint-disable-next-line svelte/no-at-html-tags -->
           {@html entree.texte}
         </a>

--- a/src/lib/lab/blog/SommaireMobile.svelte
+++ b/src/lib/lab/blog/SommaireMobile.svelte
@@ -4,9 +4,13 @@
   import IconeMenuLateral from "$lib/lab/blog/IconeMenuLateral.svelte";
   import IconeChevronBas from "$lib/lab/blog/IconeChevronBas.svelte";
 
-  export let tableDesMatieres: TableDesMatieres;
+  interface Props {
+    tableDesMatieres: TableDesMatieres;
+  }
 
-  let detailsElement: HTMLDetailsElement;
+  let { tableDesMatieres }: Props = $props();
+
+  let detailsElement: HTMLDetailsElement = $state();
 
   const emets = createEventDispatcher<{
     ancreOuverte: string;
@@ -34,7 +38,7 @@
     <ul>
       {#each tableDesMatieres as entree (entree.id)}
         <li>
-          <a href={`#${entree.id}`} on:click={() => ouvreEntree(entree.id)}>
+          <a href={`#${entree.id}`} onclick={() => ouvreEntree(entree.id)}>
             <!-- eslint-disable-next-line svelte/no-at-html-tags -->
             {@html entree.texte}</a
           >
@@ -58,7 +62,7 @@
       display: none;
     }
 
-    &:has(details[open]) {
+    &:has(:global(details[open])) {
       position: fixed;
       top: 0;
       height: 100vh;


### PR DESCRIPTION
Cette PR effectue l'ensemble des évolutions de code permettant de passer de Svelte 4 à Svelte 5, pour les composants suivants :

- Composant **BandeauTitre**
- Composant **CarteArticle**
- Composant **ListeArticles**
- Composant **ListeDeroulante**
- Composant **PageCrisp**
- Composant **SommaireBureau**
- Composant **SommaireMobile**