### PR TITLE
Migration des composants "Suite Cyber" en Svelte 5

### DIFF
--- a/src/lib/suite-cyber/navigation/BlocLiens.svelte
+++ b/src/lib/suite-cyber/navigation/BlocLiens.svelte
@@ -7,8 +7,12 @@
     classeTracking: string;
   };
 
-  export let titre: string;
-  export let services: Service[];
+  interface Props {
+    titre: string;
+    services: Service[];
+  }
+
+  let { titre, services }: Props = $props();
 </script>
 
 <div class="bloc">

--- a/src/lib/suite-cyber/navigation/Navigation.svelte
+++ b/src/lib/suite-cyber/navigation/Navigation.svelte
@@ -14,15 +14,19 @@
   const mss = srcAsset("/icones/MSS.svg");
   const lienExterne = srcAsset("/icones/lien-externe.svg");
 
-  export let sourceUtm: string = "";
-  let estOuvert: boolean = false;
+  interface Props {
+    sourceUtm?: string;
+  }
+
+  let { sourceUtm = "" }: Props = $props();
+  let estOuvert: boolean = $state(false);
 </script>
 
 <div class="suite-cyber">
   <div class="navigation">
     <button
       class:actif={estOuvert}
-      on:click={() => {
+      onclick={() => {
         estOuvert = !estOuvert;
       }}
     >
@@ -35,7 +39,7 @@
   </div>
   {#if estOuvert}
     <div class="contenu" transition:slide>
-      <button class="fermer invisible-tablette" on:click={() => (estOuvert = false)}>
+      <button class="fermer invisible-tablette" onclick={() => (estOuvert = false)}>
         Fermer
         <img src={croix} alt="Fermer" />
       </button>


### PR DESCRIPTION
Cette PR effectue l'ensemble des évolutions de code permettant de passer de Svelte 4 à Svelte 5, pour les composants suivants :

- Composant **BlocLiens**
- Composant **Navigation**