### PR TITLE
Migration des composants "Services Cyber" en Svelte 5

### DIFF
--- a/src/lib/mes-services-cyber/bandeau/Bandeau.svelte
+++ b/src/lib/mes-services-cyber/bandeau/Bandeau.svelte
@@ -6,7 +6,9 @@
   const CLE_LOCAL_STORAGE = "lab-anssi-ui-kit-msc-bandeau-affichage";
 
   type visibilite = "visible" | "invisible";
-  let affichage: visibilite = (localStorage.getItem(CLE_LOCAL_STORAGE) as visibilite) || "visible";
+  let affichage: visibilite = $state(
+    (localStorage.getItem(CLE_LOCAL_STORAGE) as visibilite) || "visible",
+  );
 
   const croix = srcAsset("/icones/croix-blanche.svg");
 </script>
@@ -16,7 +18,7 @@
     <div class="contenu">
       <button
         class="fermer"
-        on:click={() => {
+        onclick={() => {
           affichage = "invisible";
           localStorage.setItem(CLE_LOCAL_STORAGE, "invisible");
         }}

--- a/src/lib/mes-services-cyber/lien/LienDiagnosticCyber.svelte
+++ b/src/lib/mes-services-cyber/lien/LienDiagnosticCyber.svelte
@@ -3,8 +3,12 @@
 <script lang="ts">
   import { srcAsset } from "$lib/assets/assets";
 
-  export let lien;
-  export let versExterne = false;
+  interface Props {
+    lien: any;
+    versExterne?: boolean;
+  }
+
+  let { lien, versExterne = false }: Props = $props();
   let target = versExterne ? "_blank" : "_self";
   let rel = versExterne ? "noreferrer" : undefined;
   let icone = versExterne ? "lien-externe" : "lien-interne";


### PR DESCRIPTION
Cette PR effectue l'ensemble des évolutions de code permettant de passer de Svelte 4 à Svelte 5, pour les composants suivants :

- Composant **Bandeau**
- Composant **LienDiagnosticCyber**