### PR TITLE
Migration des composants "Marelle" en Svelte 5

### DIFF
--- a/src/lib/lab/vitrines-produits/briques/marelle/Etape.svelte
+++ b/src/lib/lab/vitrines-produits/briques/marelle/Etape.svelte
@@ -2,8 +2,12 @@
   import type { EtapeMarelle } from "$lib/types";
   import LienExterne from "$lib/lab/icones/LienExterne.svelte";
 
-  export let index: number;
-  export let etapeMarelle: EtapeMarelle;
+  interface Props {
+    index: number;
+    etapeMarelle: EtapeMarelle;
+  }
+
+  let { index, etapeMarelle }: Props = $props();
 </script>
 
 <div class="marelle-etape">

--- a/src/lib/lab/vitrines-produits/briques/marelle/Marelle.svelte
+++ b/src/lib/lab/vitrines-produits/briques/marelle/Marelle.svelte
@@ -15,9 +15,13 @@
   import Etape from "$lib/lab/vitrines-produits/briques/marelle/Etape.svelte";
   import LienExterne from "$lib/lab/icones/LienExterne.svelte";
 
-  export let titre: string = "";
-  export let etapesmarelle: EtapeMarelle[] = [];
-  export let action: Action;
+  interface Props {
+    titre?: string;
+    etapesmarelle?: EtapeMarelle[];
+    action: Action;
+  }
+
+  let { titre = "", etapesmarelle = [], action }: Props = $props();
 </script>
 
 <Brique variation="secondaire">


### PR DESCRIPTION
Cette PR effectue l'ensemble des évolutions de code permettant de passer de Svelte 4 à Svelte 5, pour les composants suivants :

- Composant **Etape**
- Composant **Marelle**