### PR TITLE
Migration des composants transverses en Svelte 5

### DIFF
--- a/src/lib/Alerte.svelte
+++ b/src/lib/Alerte.svelte
@@ -10,11 +10,15 @@
 />
 
 <script lang="ts">
-  export let description: string;
-  export let type: "information" | "erreur" = "information";
-  export let fermable: boolean = true;
+  interface Props {
+    description: string;
+    type?: "information" | "erreur";
+    fermable?: boolean;
+  }
 
-  let estOuvert = true;
+  let { description, type = "information", fermable = true }: Props = $props();
+
+  let estOuvert = $state(true);
 </script>
 
 {#if estOuvert}
@@ -25,7 +29,7 @@
       {#if fermable}
         <button
           class="fermer"
-          on:click={() => {
+          onclick={() => {
             estOuvert = false;
           }}
         ></button>

--- a/src/lib/CentreAide.svelte
+++ b/src/lib/CentreAide.svelte
@@ -1,35 +1,41 @@
 <svelte:options customElement="lab-anssi-centre-aide" />
 
 <script lang="ts">
+  import { run } from "svelte/legacy";
+
   import { fly } from "svelte/transition";
   import { createEventDispatcher } from "svelte";
   import { srcAsset } from "$lib/assets/assets";
 
-  export let nomService: string;
-  export let liens: string;
+  interface Props {
+    nomService: string;
+    liens: string;
+  }
+
+  let { nomService, liens }: Props = $props();
 
   const emetEvenement = createEventDispatcher<{
     lienclique: { target: EventTarget & HTMLAnchorElement };
   }>();
 
   let liensMisEnForme: { texte: string; href?: string; preventDefault?: boolean; id?: string }[] =
-    [];
-  $: {
+    $state([]);
+  run(() => {
     liensMisEnForme = JSON.parse(liens);
     if (!Array.isArray(liensMisEnForme) || liensMisEnForme.some((l) => !l.texte)) {
       throw new Error(
         "Les liens doivent respecter le type : { texte: string; href?: string; preventDefault?: boolean; id?: string }[]",
       );
     }
-  }
+  });
 
-  let ouvert: boolean = false;
+  let ouvert: boolean = $state(false);
 </script>
 
 {#if !ouvert}
   <button
     class="declencheur-centre-aide"
-    on:click={() => (ouvert = true)}
+    onclick={() => (ouvert = true)}
     transition:fly={{ y: 300 }}
   >
     <img src={srcAsset("/icones/centre-aide.svg")} alt="Icône du centre d'aide" />
@@ -48,7 +54,7 @@
         />
         <h4>Centre d'aide</h4>
       </div>
-      <button on:click={() => (ouvert = false)}>
+      <button onclick={() => (ouvert = false)}>
         <span>Fermer</span>
         <img
           src={srcAsset("/icones/croix-blanche.svg")}
@@ -67,7 +73,7 @@
             href={lien.href}
             target="_blank"
             id={lien.id}
-            on:click={(e) => {
+            onclick={(e) => {
               if (lien.preventDefault) e.preventDefault();
               emetEvenement("lienclique", { target: e.currentTarget });
             }}>{lien.texte}</a

--- a/src/lib/lab/icones/Fleche.svelte
+++ b/src/lib/lab/icones/Fleche.svelte
@@ -1,5 +1,9 @@
 <script lang="ts">
-  export let direction: "gauche" | "droite" = "gauche";
+  interface Props {
+    direction?: "gauche" | "droite";
+  }
+
+  let { direction = "gauche" }: Props = $props();
 </script>
 
 <svg

--- a/src/lib/lab/icones/LienExterne.svelte
+++ b/src/lib/lab/icones/LienExterne.svelte
@@ -1,5 +1,9 @@
 <script lang="ts">
-  export let couleur: string | undefined = undefined;
+  interface Props {
+    couleur?: string | undefined;
+  }
+
+  let { couleur = undefined }: Props = $props();
 </script>
 
 <svg

--- a/src/lib/pied-de-page/NavigationPiedDePage.svelte
+++ b/src/lib/pied-de-page/NavigationPiedDePage.svelte
@@ -1,7 +1,11 @@
 <svelte:options customElement="lab-anssi-navigation-pied-de-page" />
 
 <script lang="ts">
-  export let conforme: boolean = false;
+  interface Props {
+    conforme?: boolean;
+  }
+
+  let { conforme = false }: Props = $props();
 </script>
 
 <div class="conteneur-navigation-pied-de-page">

--- a/stories/ConteneurStory.svelte
+++ b/stories/ConteneurStory.svelte
@@ -1,6 +1,11 @@
 <script lang="ts">
-  export let hauteurMinimale: string | undefined = "600px";
-  export let alignement: "gauche" | "droite" | undefined = undefined;
+  interface Props {
+    hauteurMinimale?: string | undefined;
+    alignement?: "gauche" | "droite" | undefined;
+    children?: import("svelte").Snippet;
+  }
+
+  let { hauteurMinimale = "600px", alignement = undefined, children }: Props = $props();
 </script>
 
 <div
@@ -8,7 +13,7 @@
   class:conteneur-story--droite={alignement === "droite"}
   style={hauteurMinimale ? `--min-height: ${hauteurMinimale};` : null}
 >
-  <slot />
+  {@render children?.()}
 </div>
 
 <style lang="scss">


### PR DESCRIPTION
Cette PR effectue l'ensemble des évolutions de code permettant de passer de Svelte 4 à Svelte 5, pour les composants suivants :

- Composant **Alerte**
- Composant **CentreAide**
- Composant **Fleche**
- Composant **LienExterne**
- Composant **NavigationPiedDePage**
- Composant  **ConteneurStory**