### PR TITLE
[CI/CD] Passe la version de Node.js à la version 24

### DIFF
--- a/.github/workflows/integration-continue.yml
+++ b/.github/workflows/integration-continue.yml
@@ -17,10 +17,10 @@ jobs:
       - name: Cloner le dépôt Git
         uses: actions/checkout@v4
 
-      - name: Utiliser la version Node.js 22
+      - name: Utiliser la version Node.js 24
         uses: actions/setup-node@v3
         with:
-          node-version: 22
+          node-version: 24
 
       - name: Installer les dépendances
         run: npm ci

--- a/.github/workflows/publication-npm.yml
+++ b/.github/workflows/publication-npm.yml
@@ -20,7 +20,7 @@ jobs:
       - name: Installer Node.js
         uses: actions/setup-node@v3
         with:
-          node-version: 22
+          node-version: 24
           registry-url: "https://registry.npmjs.org/"
 
       - name: Installer les dépendances

--- a/.github/workflows/publication-storybook-dev.yml
+++ b/.github/workflows/publication-storybook-dev.yml
@@ -12,10 +12,10 @@ jobs:
       - name: Cloner le dépôt Git
         uses: actions/checkout@v4
 
-      - name: Utiliser la version Node.js 22
+      - name: Utiliser la version Node.js 24
         uses: actions/setup-node@v3
         with:
-          node-version: 22
+          node-version: 24
 
       - name: Installer les dépendances
         run: npm ci

--- a/.github/workflows/publication-storybook.yml
+++ b/.github/workflows/publication-storybook.yml
@@ -14,10 +14,10 @@ jobs:
       - name: Cloner le dépôt Git
         uses: actions/checkout@v4
 
-      - name: Utiliser la version Node.js 22
+      - name: Utiliser la version Node.js 24
         uses: actions/setup-node@v3
         with:
-          node-version: 22
+          node-version: 24
 
       - name: Installer les dépendances
         run: npm ci

--- a/.github/workflows/test-storybook.yml
+++ b/.github/workflows/test-storybook.yml
@@ -15,10 +15,10 @@ jobs:
       - name: Cloner le dépôt Git
         uses: actions/checkout@v4
 
-      - name: Utiliser la version Node.js 22
+      - name: Utiliser la version Node.js 24
         uses: actions/setup-node@v3
         with:
-          node-version: 22
+          node-version: 24
 
       - name: Installer les dépendances
         run: npm ci


### PR DESCRIPTION
## Décrire les changements

Cette PR mets à jour la version de Node.js installée dans les GitHub Actions vers la version 24.

## Cette PR introduit-elle un "breaking change" ?

- [ ] Yes
- [x] No

## Autres informations

Cette mise à jour est effectuée pour être en alignement avec [la documentation](https://github.com/betagouv/lab-anssi-ui-kit/pull/146) compte tenu de la dépréciation prochaine de Node.js 22.