### PR TITLE
[COMPOSANTS] - DSFR - Supprime le shadow-root des composants

### DIFF
--- a/src/lib/dsfr/DsfrAlert.svelte
+++ b/src/lib/dsfr/DsfrAlert.svelte
@@ -1,6 +1,7 @@
 <svelte:options
   customElement={{
     tag: "dsfr-alert",
+    shadow: "none",
     props: {
       buttonCloseLabel: { attribute: "button-close-label", type: "String" },
       hasTitle: { attribute: "has-title", type: "Boolean" },
@@ -66,8 +67,3 @@
     </button>
   {/if}
 </div>
-
-<style lang="scss">
-  @import "@gouvfr/dsfr/dist/core/core.min.css";
-  @import "@gouvfr/dsfr/dist/component/alert/alert.min.css";
-</style>

--- a/src/lib/dsfr/DsfrBadge.svelte
+++ b/src/lib/dsfr/DsfrBadge.svelte
@@ -1,6 +1,7 @@
 <svelte:options
   customElement={{
     tag: "dsfr-badge",
+    shadow: "none",
     props: {
       label: { attribute: "label", type: "String" },
       accent: { attribute: "accent", type: "String" },
@@ -62,9 +63,3 @@
     {label}
   {/if}
 </p>
-
-<style lang="scss">
-  @use "@gouvfr/dsfr/src/dsfr/core/style/color/module/_decisions.scss";
-  @import "@gouvfr/dsfr/dist/core/core.min.css";
-  @import "@gouvfr/dsfr/dist/component/badge/badge.min.css";
-</style>

--- a/src/lib/dsfr/DsfrButton.svelte
+++ b/src/lib/dsfr/DsfrButton.svelte
@@ -1,6 +1,7 @@
 <svelte:options
   customElement={{
     tag: "dsfr-button",
+    shadow: "none",
     props: {
       hasIcon: { attribute: "has-icon", type: "Boolean" },
       icon: { attribute: "icon", type: "String" },
@@ -84,8 +85,8 @@
 </svelte:element>
 
 <style lang="scss">
-  @import "@gouvfr/dsfr/dist/core/core.min.css";
-  @import "@gouvfr/dsfr/dist/component/button/button.min.css";
+  // @import "@gouvfr/dsfr/dist/core/core.min.css";
+  // @import "@gouvfr/dsfr/dist/component/button/button.min.css";
 
   .fr-btn {
     box-sizing: border-box;

--- a/src/lib/dsfr/DsfrContainer.svelte
+++ b/src/lib/dsfr/DsfrContainer.svelte
@@ -26,14 +26,3 @@
 <div class={[!fluid && "fr-container", fluid && "fr-container--fluid"]}>
   {@render children?.()}
 </div>
-
-<style lang="scss">
-  @import "@gouvfr/dsfr/dist/core/core.min.css";
-
-  .fr-container {
-    &,
-    &--fluid {
-      box-sizing: border-box;
-    }
-  }
-</style>

--- a/stories/dsfr/Alert.stories.svelte
+++ b/stories/dsfr/Alert.stories.svelte
@@ -6,6 +6,10 @@
   } from "@gouvfr/dsfr/src/dsfr/component/alert/template/stories/alert-arg-types.js";
   import DsfrAlert from "$lib/dsfr/DsfrAlert.svelte";
 
+  // Styles
+  import "@gouvfr/dsfr/dist/core/core.min.css";
+  import "@gouvfr/dsfr/dist/component/alert/alert.min.css";
+
   const { Story } = defineMeta({
     title: "Composants/dsfr/Alert",
     component: DsfrAlert,

--- a/stories/dsfr/Badge.stories.svelte
+++ b/stories/dsfr/Badge.stories.svelte
@@ -6,6 +6,10 @@
   } from "@gouvfr/dsfr/src/dsfr/component/badge/template/stories/badge-arg-types.js";
   import DsfrBadge from "$lib/dsfr/DsfrBadge.svelte";
 
+  // Styles
+  import "@gouvfr/dsfr/dist/core/core.min.css";
+  import "@gouvfr/dsfr/dist/component/badge/badge.min.css";
+
   const { Story } = defineMeta({
     title: "Composants/dsfr/Badge",
     component: DsfrBadge,

--- a/stories/dsfr/Button.stories.svelte
+++ b/stories/dsfr/Button.stories.svelte
@@ -6,6 +6,10 @@
   } from "@gouvfr/dsfr/src/dsfr/component/button/template/stories/button-arg-types.js";
   import DsfrButton from "$lib/dsfr/DsfrButton.svelte";
 
+  // Styles
+  import "@gouvfr/dsfr/dist/core/core.min.css";
+  import "@gouvfr/dsfr/dist/component/button/button.min.css";
+
   const { Story } = defineMeta({
     title: "Composants/dsfr/Button",
     component: DsfrButton,


### PR DESCRIPTION
## Décrire les changements

### Supprime le shadow-root des composants du DSFR

Les styles du DSFR sont très peu modulaires.
Leurs utilisations dans le cadre des composants Svelte posent de nombreux problèmes comme : 
- Le nombre de sélecteurs non nécessaires au sein des feuilles de styles et qui cause un break lors du build par le compiler Svelte
- La difficulté de faire fonctionner "simplement" les icônes présentes dans les différentes feuilles de styles

En étudiant attentivement les autres portages du DSFR (React ou Vue), ils ont fait le choix de déléguer à l'utilisateur finale la responsabilité d'importer les styles du DSFR, et de ne pas les porter par la librairie _(sans doute pour les mêmes raisons listés ci-dessus)_.

Il semble donc que cela soit la meilleure option pour utiliser le DSFR de la façon la plus "optimale".

Cela pousse donc à revoir légèrement la copie dans le cadre du portage Svelte/WebC du DSFR et faire en sorte que les WebC du DSFR ne soient plus encapsulés dans un shadow-root, afin de leur permettre de bénéficier des styles importés par l'utilisateur finale.

## Autres informations

<!-- Ajoutez ici tout autre commentaire ou toute autre information concernant cette Pull Request. -->
