### PR TITLE
[COMPOSANTS] Utilise la syntaxe Slot au lieu de Snippet

### DIFF
--- a/src/lib/composants/Hero.svelte
+++ b/src/lib/composants/Hero.svelte
@@ -14,14 +14,12 @@
 />
 
 <script lang="ts">
-  import type { Snippet } from "svelte";
   import DsfrContainer from "$lib/dsfr/DsfrContainer.svelte";
 
   interface Props {
     titre: string;
     baliseTitre: string;
     description: string;
-    actions?: Snippet;
     inverse?: boolean;
     urlImage?: string | undefined;
     sansImage?: boolean;
@@ -32,7 +30,6 @@
     baliseTitre = "h1",
     description,
     inverse = false,
-    actions,
     urlImage,
     sansImage = false,
   }: Props = $props();
@@ -53,9 +50,9 @@
         </svelte:element>
         <p class="lab-anssi-hero__description">{description}</p>
 
-        {#if actions}
+        {#if $$slots.actions}
           <div class="lab-anssi-hero__actions">
-            {@render actions()}
+            <slot name="actions" />
           </div>
         {/if}
       </div>

--- a/src/lib/dsfr/DsfrContainer.svelte
+++ b/src/lib/dsfr/DsfrContainer.svelte
@@ -9,22 +9,15 @@
 
 <script lang="ts">
   interface Props {
-    /**
-     * Permet de définir le conteneur comme "fluide" ou non
-     */
+    /** Permet de définir le conteneur comme "fluide" ou non */
     fluid?: boolean;
-
-    /**
-     * Permet de définir le contenu du conteneur
-     */
-    children?: import("svelte").Snippet;
   }
 
-  let { fluid = false, children }: Props = $props();
+  let { fluid = false }: Props = $props();
 </script>
 
 <div class={[!fluid && "fr-container", fluid && "fr-container--fluid"]}>
-  {@render children?.()}
+  <slot></slot>
 </div>
 
 <style lang="scss">


### PR DESCRIPTION
## Décrire les changements

**Svelte 5** introduit une nouvelle syntaxe appelée [Snippet](https://svelte.dev/docs/svelte/snippet) qui a pour objectif de remplacer l'ancienne façon d'inclure du contenu à l'intérieur d'un composant, travail qui était anciennement fait en **Svelte 4** par la syntaxe [<slot>](https://svelte.dev/docs/svelte/legacy-slots).

Cependant, dans le cadre d'une utilisation des composants en **custom elements**, Svelte recommande de maintenir encore l'utilisation de la syntaxe `<slot>`.

Cette PR effectue donc les changements nécessaires en ce sens sur les premiers composants déjà livrés.

## Autres informations

**Documentation associée :**

https://svelte.dev/docs/svelte/v5-migration-guide#Snippets-instead-of-slots

**Commentaire complémentaire extrait de la documentation :** 
> When using custom elements, you should still use <slot /> like before. In a future version, when Svelte removes its internal version of slots, it will leave those slots as-is, i.e. output a regular DOM tag instead of transforming it.
