### PR TITLE
[CORRECTION] Rétablis le lancement de Storybook en dev

### DIFF
--- a/.storybook/main.ts
+++ b/.storybook/main.ts
@@ -22,7 +22,14 @@ const config: StorybookConfig = {
       ...config.server,
       fs: {
         ...config.server?.fs,
-        allow: [...(config.server?.fs?.allow || []), "./stories", "./src", "./static"],
+        allow: [
+          ...(config.server?.fs?.allow || []),
+          "./stories",
+          "./src",
+          "./static",
+          ".storybook",
+          "node_modules",
+        ],
       },
     };
     config.resolve = {


### PR DESCRIPTION
## Décrire les changements

La commande `npm run storybook:dev` ne semble plus fonctionner correctement suite aux récents changements sur le projet.
Cette PR rétabli le lancement de Storybook en dev.

## Autres informations

<!-- Ajoutez ici tout autre commentaire ou toute autre information concernant cette Pull Request. -->
