### PR TITLE
[OUTILS] Spécifie l'usage de PurgeCSS uniquement pour les composants DSFR

### DIFF
--- a/vite.webcomponents.config.ts
+++ b/vite.webcomponents.config.ts
@@ -36,7 +36,7 @@ export default defineConfig({
     postcss: {
       plugins: [
         purgeCSSPlugin({
-          content: ["**/*.svelte"],
+          content: ["src/lib/dsfr/**/*.svelte"],
           blocklist: [
             // supprime la police Marianne
             "@font-face",


### PR DESCRIPTION
## Décrire les changements

L'usage de **PurgeCSS** dans le process de build des **WebComposants** posent de nombreux problèmes.
Il faudrait s'en passer et aller vers une autre solution qui nous permette de gérer plus finement l'import des styles.

Par ailleurs, pour l'instant **PurgeCSS** s'appliquant sur la totalité des composants, cela engendre des effets de bords sur les composants du Lab et engendre des breakings sur les projets autres que DSC.

Pour corriger ce dernier point le plus rapidement possible, en attendant le retrait définitif de **PurgeCSS**, cette PR spécifie l'usage de **PurgeCSS** uniquement pour les composants DSFR.

## Autres informations

<!-- Ajoutez ici tout autre commentaire ou toute autre information concernant cette Pull Request. -->
