### PR TITLE
[OUTIL] Supprime l'usage de `PurgeCSS` & `discardEmptyBlocks`

### DIFF
--- a/src/lib/dsfr/DsfrAlert.svelte
+++ b/src/lib/dsfr/DsfrAlert.svelte
@@ -68,6 +68,6 @@
 </div>
 
 <style lang="scss">
-  @use "@gouvfr/dsfr/src/dsfr/main" as *;
+  @use "@gouvfr/dsfr/src/dsfr/core/main" as *;
   @use "@gouvfr/dsfr/src/dsfr/component/alert/main" as *;
 </style>

--- a/src/lib/dsfr/DsfrBadge.svelte
+++ b/src/lib/dsfr/DsfrBadge.svelte
@@ -64,6 +64,6 @@
 </p>
 
 <style lang="scss">
-  @use "@gouvfr/dsfr/src/dsfr/main" as *;
+  @use "@gouvfr/dsfr/src/dsfr/core/main" as *;
   @use "@gouvfr/dsfr/src/dsfr/component/badge/main" as *;
 </style>

--- a/src/lib/dsfr/DsfrButton.svelte
+++ b/src/lib/dsfr/DsfrButton.svelte
@@ -89,7 +89,7 @@
 </svelte:element>
 
 <style lang="scss">
-  @use "@gouvfr/dsfr/src/dsfr/main" as *;
+  @use "@gouvfr/dsfr/src/dsfr/core/main" as *;
   @use "@gouvfr/dsfr/src/dsfr/component/button/main" as *;
   @use "./icones" as *;
 

--- a/src/lib/dsfr/DsfrContainer.svelte
+++ b/src/lib/dsfr/DsfrContainer.svelte
@@ -21,5 +21,5 @@
 </div>
 
 <style lang="scss">
-  @use "@gouvfr/dsfr/src/dsfr/main" as *;
+  @use "@gouvfr/dsfr/src/dsfr/core/main" as *;
 </style>

--- a/vite.webcomponents.config.ts
+++ b/vite.webcomponents.config.ts
@@ -1,8 +1,6 @@
-import { purgeCSSPlugin } from "@fullhuman/postcss-purgecss";
 import { svelte } from "@sveltejs/vite-plugin-svelte";
 import cssnano from "cssnano";
 import path, { resolve } from "path";
-import { default as discardEmptyBlocks } from "postcss-discard-empty";
 import root2host from "postcss-root-to-host";
 import { defineConfig, loadEnv } from "vite";
 import injecteNonce from "./outils/vite-plugin-injecte-nonce";
@@ -35,32 +33,7 @@ export default defineConfig({
   css: {
     postcss: {
       plugins: [
-        purgeCSSPlugin({
-          content: ["**/*.svelte"],
-          blocklist: [
-            // supprime la police Marianne
-            "@font-face",
-            // suppprime les variables commençant par ces préfixes
-            /^--background-.*/,
-            /^--text-.*/,
-            /^--border-.*/,
-            /^--grey-.*/,
-            /^--blue-.*/,
-            /^--info-.*/,
-          ],
-          safelist: [
-            // ":host",
-            // garde les styles des états
-            /^·*--hover$/g,
-            /^·*--active$/g,
-            /^·*--focus$/g,
-            /^·*--disabled$/g,
-            // garde toutes les icones !
-            /^\.fr-icon-.*$/,
-          ],
-        }),
         root2host,
-        discardEmptyBlocks(),
         cssnano({
           preset: [
             "default",


### PR DESCRIPTION
## Décrire les changements

L'implémentation de `PurgeCSS` dans un [précédent commit](https://github.com/betagouv/lab-anssi-ui-kit/commit/09282ef0339794422fb5d0beaa4cd7f73673c577) pose de nombreux problèmes dû à la difficulté de personnaliser `PurgeCSS` de façon assez fine pour lui permettre de gérer avec efficacité tous les cas de figure de nos composants.

Il faudrait donc changer la logique avec laquelle nous important/utilisant les styles et notamment les styles en provenance du DSFR où plutôt que de supprimer les styles non utilisés il faudrait plutôt importer uniquement les styles nécessaires.

En attendant la mise en oeuvre de ce travail, cette PR supprime l'usage de `PurgeCSS` de façon à régler les problèmes rencontrés actuellement et notamment sur les projets autres que DSC.

Cette PR supprime également l'usage du plugin `discardEmptyBlocks` car ce dernier est déjà inclu par défaut dans `cssnano`.

## Liens utiles

- [Optimisations cssnano](https://cssnano.github.io/cssnano/docs/what-are-optimisations/#what-optimisations-do-you-support%3F)
