### PR TITLE
[BUG] Corrige le menu latéral DSFR

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@lab-anssi/ui-kit",
-  "version": "1.28.1",
+  "version": "1.28.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@lab-anssi/ui-kit",
-      "version": "1.28.1",
+      "version": "1.28.2",
       "license": "Apache-2.0",
       "devDependencies": {
         "@chromatic-com/storybook": "^4.1.1",
@@ -6787,21 +6787,6 @@
         "picomatch": {
           "optional": true
         }
-      }
-    },
-    "node_modules/svelte-check/node_modules/picomatch": {
-      "version": "4.0.3",
-      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.3.tgz",
-      "integrity": "sha512-5gTmgEY/sqK6gFXLIsQNH19lWb4ebPDLA4SdLP7dsWkIXHWlG66oPuVvXSGFPppYZz8ZDZq0dYYrbHfBCVUb1Q==",
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "peer": true,
-      "engines": {
-        "node": ">=12"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/jonschlinkert"
       }
     },
     "node_modules/svelte-eslint-parser": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@lab-anssi/ui-kit",
-  "version": "1.28.1",
+  "version": "1.28.2",
   "repository": {
     "type": "git",
     "url": "git+https://github.com/betagouv/lab-anssi-ui-kit.git"

--- a/src/lib/dsfr/DsfrSideMenu.svelte
+++ b/src/lib/dsfr/DsfrSideMenu.svelte
@@ -45,6 +45,7 @@
   }
 
   let { title, titleId, hasTitle = true, items, modifier, buttonLabel, buttonId }: Props = $props();
+  let collapseElement: HTMLDivElement;
 
   const COLLAPSE_ID_PREFIX = "sidemenu-collapse-";
 
@@ -63,17 +64,13 @@
   function handleClick(event: MouseEvent) {
     const button = event.target as HTMLButtonElement;
     const ariaExpanded = button.ariaExpanded;
-    const ariaControls = button.getAttribute("aria-controls");
     const isExpanded = ariaExpanded === "true";
     button.ariaExpanded = (!isExpanded).toString();
 
-    const collapseElement = ariaControls ? document.getElementById(ariaControls) : null;
-    if (collapseElement) {
-      if (isExpanded) {
-        collapseElement.classList.remove("fr-collapse--expanded");
-      } else {
-        collapseElement.classList.add("fr-collapse--expanded");
-      }
+    if (isExpanded) {
+      collapseElement.classList.remove("fr-collapse--expanded");
+    } else {
+      collapseElement.classList.add("fr-collapse--expanded");
     }
   }
 </script>
@@ -118,7 +115,7 @@
     >
       {buttonLabel}
     </button>
-    <div class="fr-collapse" id={buttonId}>
+    <div class="fr-collapse" id={buttonId} bind:this={collapseElement}>
       {#if hasTitle && title}
         <p class="fr-sidemenu__title" id={titleId}>
           {title}


### PR DESCRIPTION
## Décrire les changements

Le fonctionnement interne du `DsfrSideMenu` se repose sur un `document.getElementById` qui ne fonctionne pas dans un shadowRoot. Nous proposons de se baser sur une référence interne avec un `bind:this`

## Cette PR introduit-elle un "breaking change" ?

- [ ] Yes
- [x] No
