### PR TITLE
[COMPOSANT] - DSFR Button - Ajoute l'usage des icônes

### DIFF
--- a/src/lib/dsfr/DsfrButton.svelte
+++ b/src/lib/dsfr/DsfrButton.svelte
@@ -63,6 +63,9 @@
   }
 
   const iconClass = $derived<boolean | string>(hasIcon && icon && setIconClass(icon));
+  let iconPlaceClass = $derived.by(() => {
+    return hasIcon && iconPlace !== "only" && `fr-btn--icon-${iconPlace}`;
+  });
 </script>
 
 <svelte:element
@@ -73,25 +76,15 @@
   target={markup === "a" ? target : undefined}
   {disabled}
   {title}
-  class={["fr-btn", iconClass]}
-  class:fr-btn--primary={kind === "primary"}
-  class:fr-btn--secondary={kind === "secondary"}
-  class:fr-btn--tertiary={kind === "tertiary"}
-  class:fr-btn--tertiary-no-outline={kind === "tertiary-no-outline"}
-  class:fr-btn--inverted={kind === "inverted"}
-  class:fr-btn--sm={size === "sm"}
-  class:fr-btn--md={size === "md"}
-  class:fr-btn--lg={size === "lg"}
-  class:fr-btn--icon-left={hasIcon && iconPlace === "left"}
-  class:fr-btn--icon-right={hasIcon && iconPlace === "right"}
+  class={["fr-btn", `fr-btn--${kind}`, `fr-btn--${size}`, iconClass, iconPlaceClass]}
 >
   {label}
 </svelte:element>
 
 <style lang="scss">
   @use "@gouvfr/dsfr/src/dsfr/core/main" as *;
+  @use "@gouvfr/dsfr/src/dsfr/utility/main";
   @use "@gouvfr/dsfr/src/dsfr/component/button/main" as *;
-  @use "./icones" as *;
 
   .fr-btn {
     box-sizing: border-box;
@@ -106,22 +99,5 @@
       box-shadow: inset 0 0 0 1px var(--background-default-grey);
       color: var(--text-action-high-blue-france);
     }
-
-    // Inclus les icônes utilisables dans les boutons
-    @include icone(arrow-down-s-line, "arrows");
-    @include icone(arrow-left-s-line, "arrows");
-    @include icone(arrow-right-line, "arrows");
-    @include icone(arrow-right-s-line, "arrows");
-    @include icone(arrow-up-line, "arrows");
-    @include icone(fr--arrow-left-s-first-line, "arrows");
-    @include icone(fr--arrow-right-s-last-line, "arrows");
-    @include icone(add-line, "system");
-    @include icone(close-circle-line, "system");
-    @include icone(close-line, "system");
-    @include icone(delete-bin-line, "system");
-    @include icone(external-link-line, "system");
-    @include icone(menu-fill, "system");
-    @include icone(search-line, "system");
-    @include icone(user-add-line, "system");
   }
 </style>

--- a/src/lib/dsfr/icones.scss
+++ b/src/lib/dsfr/icones.scss
@@ -1,7 +1,0 @@
-@mixin icone($name, $categorie) {
-  &:global(.fr-icon-#{$name}::after),
-  &:global(.fr-icon-#{$name}::before) {
-    -webkit-mask-image: url("/icons/#{$categorie}/#{$name}.svg");
-    mask-image: url("/icons/#{$categorie}/#{$name}.svg");
-  }
-}


### PR DESCRIPTION
## Décrire les changements

Cette PR annule les implémentations faite dans [un précédent commit](https://github.com/betagouv/lab-anssi-ui-kit/commit/3477e0b46d23f842c09a3c437a6afb29e982b731) et implémente une façon plus pérènne & "DSFR Friendly" d'implémenter les icônes dans le composant `DsfrButton`.



## Autres informations

<!-- Ajoutez ici tout autre commentaire ou toute autre information concernant cette Pull Request. -->
