### PR TITLE
[BUG] Annulation de l'override des styles des fieldsets

### DIFF
--- a/src/lib/dsfr/DsfrCheckboxesGroup.svelte
+++ b/src/lib/dsfr/DsfrCheckboxesGroup.svelte
@@ -140,21 +140,4 @@
 
   @include set-shadow-host();
   @include set-dsfr-sizing("fieldset");
-
-  .fr-fieldset {
-    margin: 0;
-    padding: 0;
-
-    .fr-fieldset {
-      &__legend {
-        margin: 0;
-        padding-left: 0;
-        padding-right: 0;
-      }
-
-      &__element {
-        padding: 0;
-      }
-    }
-  }
 </style>

--- a/src/lib/dsfr/DsfrRadiosGroup.svelte
+++ b/src/lib/dsfr/DsfrRadiosGroup.svelte
@@ -137,27 +137,4 @@
 
   @include set-shadow-host();
   @include set-dsfr-sizing("fieldset");
-
-  .fr-fieldset {
-    margin: 0;
-    padding: 0;
-
-    &__legend {
-      margin: 0;
-      padding-left: 0;
-      padding-right: 0;
-    }
-
-    &__element {
-      padding: 0;
-
-      &--inline:not(:first-of-type) {
-        padding-left: 8px;
-      }
-
-      &--inline:not(:last-of-type) {
-        padding-right: 8px;
-      }
-    }
-  }
 </style>


### PR DESCRIPTION
## Décrire les changements

L'override des styles de la la balise `fieldset` effectuée dans des précédents commits ([ici](https://github.com/betagouv/lab-anssi-ui-kit/commit/23a848bcd36b4366695eb32638e3483a26a55a6f) & [ici](https://github.com/betagouv/lab-anssi-ui-kit/commit/ed6352b75ce1e6a3e9be3d45444f123cfc2e1362)) posent un problème d'affichage dans les composants `DsfrCheckboxesGroup` & `DsfrRadiosGroup` pour leurs variations `valid` et `error` _(cf: screenshot)_.

<img width="557" height="239" alt="Capture d'écran 2025-10-02 170854" src="https://github.com/user-attachments/assets/f4f4d750-45b3-4592-baf5-1e55c8751166" />

Cette PR effectue donc un rollback sur ces modifications afin de conserver le style par défaut des composants.

Une prochaine PR s'attachera à résoudre le pb qui a conduit à ces overrides, sans doute à faire côté DSC.

## Autres informations

<!-- Ajoutez ici tout autre commentaire ou toute autre information concernant cette Pull Request. -->
