### PR TITLE
[MENU-LATERAL] Corrige side menu

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@lab-anssi/ui-kit",
-  "version": "1.28.2",
+  "version": "1.28.3",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@lab-anssi/ui-kit",
-      "version": "1.28.2",
+      "version": "1.28.3",
       "license": "Apache-2.0",
       "devDependencies": {
         "@chromatic-com/storybook": "^4.1.1",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@lab-anssi/ui-kit",
-  "version": "1.28.2",
+  "version": "1.28.3",
   "repository": {
     "type": "git",
     "url": "git+https://github.com/betagouv/lab-anssi-ui-kit.git"

--- a/src/lib/dsfr/DsfrSideMenu.svelte
+++ b/src/lib/dsfr/DsfrSideMenu.svelte
@@ -64,14 +64,24 @@
   function handleClick(event: MouseEvent) {
     const button = event.target as HTMLButtonElement;
     const ariaExpanded = button.ariaExpanded;
+    const ariaControls = button.getAttribute("aria-controls");
     const isExpanded = ariaExpanded === "true";
     button.ariaExpanded = (!isExpanded).toString();
 
-    if (isExpanded) {
-      collapseElement.classList.remove("fr-collapse--expanded");
-    } else {
-      collapseElement.classList.add("fr-collapse--expanded");
+    const collapseElement = ariaControls ? button.parentElement.querySelector(`#${ariaControls}`) : null;
+    if (collapseElement) {
+      if (isExpanded) {
+        collapseElement.classList.remove("fr-collapse--expanded");
+      } else {
+        collapseElement.classList.add("fr-collapse--expanded");
+      }
     }
+  }
+
+  function handleClickLeaf(event: MouseEvent) {
+    triggerButton.ariaExpanded = "false";
+    collapseElement.ariaExpanded = "false";
+    collapseElement.classList.remove("fr-collapse--expanded");
   }
 </script>
 

--- a/stories/dsfr/SideMenu.stories.svelte
+++ b/stories/dsfr/SideMenu.stories.svelte
@@ -1,16 +1,47 @@
-<script module>
-  import { defineMeta } from "@storybook/addon-svelte-csf";
+<script module lang="ts">
+  import DsfrSideMenu from "$lib/dsfr/DsfrSideMenu.svelte";
   import {
     sidemenuArgTypes,
     sidemenuArgs,
   } from "@gouvfr/dsfr/src/dsfr/component/sidemenu/template/stories/sidemenu-arg-types.js";
-  import DsfrSideMenu from "$lib/dsfr/DsfrSideMenu.svelte";
+  import { defineMeta } from "@storybook/addon-svelte-csf";
+
+  const getItemArgs = (id: string | number, type = "link", isActive = false) => ({
+    id: type === "link" ? `sidemenu-item-${id}` : `sidemenu-${id}`,
+    label: `Titre du ${type === "link" ? "lien" : "menu"} ${id}`,
+    href: type === "link" && "#",
+    type: type,
+    active: isActive,
+    isCollapsible: type === "menu",
+    collapseId: type === "menu" ? `sidemenu-${id}` : undefined,
+  });
 
   const { Story } = defineMeta({
     title: "Composants/dsfr/Side Menu",
     component: DsfrSideMenu,
     argTypes: sidemenuArgTypes,
-    args: { ...sidemenuArgs, buttonId: "sidemenu-collapse-1" },
+    args: {
+      ...sidemenuArgs,
+      items: [
+        {
+          ...getItemArgs(1, "menu", true),
+          items: [getItemArgs("1-1"), getItemArgs("1-2", "link", true), getItemArgs("1-3")],
+        },
+        getItemArgs(2),
+        {
+          ...getItemArgs(3, "menu"),
+          items: [
+            getItemArgs("3-1"),
+            {
+              ...getItemArgs("3-2", "menu"),
+              items: [getItemArgs("3-2-1"), getItemArgs("3-2-2"), getItemArgs("3-2-3")],
+            },
+            getItemArgs("3-3"),
+          ],
+        },
+      ],
+      buttonId: "sidemenu-collapse-1",
+    },
   });
 </script>
 


### PR DESCRIPTION
## Décrire les changements

Corrige la régression introduite en 1.28.2 sur le dépliage des sous menu
Et implémente le comportement du DSFR visant à replier automatiquement les menus de même niveau lorsqu'on clique sur un menu

## Cette PR introduit-elle un "breaking change" ?

- [ ] Yes
- [x] No
