### PR TITLE
[CORRECTION] Force les `mime-type` pour les assets déployés sur le S3

### DIFF
--- a/.github/workflows/publication-npm.yml
+++ b/.github/workflows/publication-npm.yml
@@ -54,7 +54,7 @@ jobs:
         run: s3cmd sync --recursive -M ./src/lib/assets/* s3://lab-anssi-ui-kit-prod-s3-assets
 
       - name: Envoyer la release js
-        run: s3cmd put --guess-mime-type ./dist/webcomponents/lab-anssi-ui-kit.iife.js s3://lab-anssi-ui-kit-prod-s3-assets/${{ env.release_version }}/
+        run: s3cmd put --mime-type='application/javascript' ./dist/webcomponents/lab-anssi-ui-kit.iife.js s3://lab-anssi-ui-kit-prod-s3-assets/${{ env.release_version }}/
 
       - name: Envoyer la feuille de style DSFR
-        run: s3cmd put --guess-mime-type ./dist/assets/dsfr-variables.css s3://lab-anssi-ui-kit-prod-s3-assets/${{ env.release_version }}/
+        run: s3cmd put --mime-type='text/css' ./dist/assets/dsfr-variables.css s3://lab-anssi-ui-kit-prod-s3-assets/${{ env.release_version }}/


### PR DESCRIPTION
## Décrire les changements

La commande `s3cmd` utilisait `guess-mime-type` qui ne semble pas fonctionner pour des fichiers CSS.
On force donc le type à la main.

## Cette PR introduit-elle un "breaking change" ?

- [ ] Yes
- [x] No

## Autres informations

<!-- Ajoutez ici tout autre commentaire ou toute autre information concernant cette Pull Request. -->
