### PR TITLE
[SASS] - DSFR Variables - Désactive la génération du fichier source map

### DIFF
--- a/package.json
+++ b/package.json
@@ -13,7 +13,7 @@
   "scripts": {
     "build": "vite build && npm run prepack",
     "build:webcomponents": "vite -c vite.webcomponents.config.ts build",
-    "build:styles:dsfr": "sass node_modules/@gouvfr/dsfr/src/dsfr/core/style/color/module/_decisions.scss dist/assets/dsfr-variables.css -I node_modules/@gouvfr/dsfr",
+    "build:styles:dsfr": "sass src/lib/styles/dsfr-variables.scss dist/assets/dsfr-variables.css -I node_modules -I node_modules/@gouvfr/dsfr --no-source-map",
     "prepare": "husky",
     "prepack": "npm run build:webcomponents && npm run copy:icons && publint",
     "test": "vitest run",

--- a/src/lib/styles/dsfr-variables.scss
+++ b/src/lib/styles/dsfr-variables.scss
@@ -1,0 +1,1 @@
+@use "@gouvfr/dsfr/src/dsfr/core/style/color/module/decisions";


### PR DESCRIPTION
## Décrire les changements

Suite à la [mise à disposition des variables CSS du DSFR](https://github.com/betagouv/lab-anssi-ui-kit/pull/202) directement dans le S3, l'erreur suivante apparait lors de la consommation de ce fichier : 

```
Refused to connect to '/dsfr-variables.css.map' because it violates the following Content Security Policy directive: "connect-src 'self'
```
Cela est dû au fait que par défaut Sass génère un fichier de mapping `.map` en plus du fichier `.css`.
Le lien vers ce fichier est contenu dans le fichier `.css` via la ligne suivante : `/*# sourceMappingURL=dsfr-variables.css.map */`.
Hors nous ne publions pas ce fichier de mapping sur le S3.

En vu de corriger ce problème cette PR effectue deux choses : 
- La création d'un fichier `dsfr-variables.scss` qui importe les variables en provenance du DSFR.<br/> L'idée est d'avoir un fichier identifié dans la lib, que l'on pourra ré-utiliser au besoin dans d'autres contextes.
- La mise à jour de la commande `build:styles:dsfr` avec l'ajout de l'option `--no-source-map` afin de désactiver la génération du fichier source map.

## Autres informations

<!-- Ajoutez ici tout autre commentaire ou toute autre information concernant cette Pull Request. -->
