### PR TITLE
[BUG] Remonte l'état 'coché' du composant DsfrCheckbox

### DIFF
--- a/src/lib/dsfr/DsfrCheckbox.svelte
+++ b/src/lib/dsfr/DsfrCheckbox.svelte
@@ -67,7 +67,7 @@
 
   function handleChange(event: Event) {
     const target = event.target as HTMLInputElement;
-    dispatch("valuechanged", target.value);
+    dispatch("valuechanged", target.checked);
   }
 </script>
 


### PR DESCRIPTION
## Décrire les changements

Remonte l'état "coché" du composant `DsfrCheckbox` dans l'évenement `valuechanged`

## Cette PR introduit-elle un "breaking change" ?

- [ ] Yes
- [x] No

## Autres informations

<!-- Ajoutez ici tout autre commentaire ou toute autre information concernant cette Pull Request. -->
