### PR TITLE
[COMPOSANT] DsfrLink - Modifie le mixin `set-shadow-host` pour piloter l'application du `font-size`

### DIFF
--- a/src/lib/dsfr/DsfrLink.svelte
+++ b/src/lib/dsfr/DsfrLink.svelte
@@ -143,7 +143,7 @@
   // DSFR Component styles
   @import "@gouvfr/dsfr/dist/component/link/link.main.css";
 
-  @include set-shadow-host("inline");
+  @include set-shadow-host("inline", false);
   @include set-dsfr-sizing("link") {
     &--neutral {
       color: currentColor;

--- a/src/lib/styles/mixins-dsfr.scss
+++ b/src/lib/styles/mixins-dsfr.scss
@@ -10,11 +10,13 @@ $checkmark-size: var(--checkmark-size, 24px) !default;
 /// @param {String} $display [block] - La valeur de la propriété CSS `display` à appliquer au `:host`.
 /// @content - Contenu CSS additionnel à insérer dans le bloc `:host`.
 ///
-@mixin set-shadow-host($display: "block") {
+@mixin set-shadow-host($display: "block", $font-size: true) {
   :host {
     display: #{$display};
     @include text-adjustments();
-    @include text-style(md);
+    @if $font-size {
+      @include text-style(md);
+    }
     @include color.background(
       default grey,
       (


### PR DESCRIPTION
## Décrire les changements

Modifie le mixin `set-shadow-host` pour piloter l'application du `font-size`

## Autres informations

<!-- Ajoutez ici tout autre commentaire ou toute autre information concernant cette Pull Request. -->
