### PR TITLE
[COMPOSANT] DsfrHeader - Ajoute la gestion des `ToolLinks` via la prop dédiée

### DIFF
--- a/src/lib/dsfr/DsfrHeader.svelte
+++ b/src/lib/dsfr/DsfrHeader.svelte
@@ -306,6 +306,8 @@
             {/if}
             {#if hasNavigation || hasSearch}
               <div class="fr-header__navbar">
+                <slot name="beforenavbarbuttons"></slot>
+
                 {#if hasSearch}
                   <button
                     data-fr-opened={openedSearchModal}
@@ -363,6 +365,8 @@
           <div class="fr-header__tools">
             {#if hasToolLinks || hasTranslate}
               <div class="fr-header__tools-links">
+                <slot name="beforetoolslinks"></slot>
+
                 <!-- Tool Links -->
                 <slot name="toolLinks">
                   {@render toolLinksRendered()}
@@ -565,6 +569,10 @@
         padding-left: 0;
         padding-right: 0;
       }
+    }
+
+    &__tools-links {
+      align-items: center;
     }
 
     @media (min-width: 62em) {

--- a/src/lib/dsfr/DsfrHeader.svelte
+++ b/src/lib/dsfr/DsfrHeader.svelte
@@ -41,6 +41,7 @@
       hasHeaderTag: { attribute: "has-header-tag", type: "Boolean" },
       fluid: { attribute: "fluid", type: "Boolean" },
     },
+    extend: withIconsStyleSheet,
   }}
 />
 
@@ -49,11 +50,23 @@
   import DsfrButton from "./DsfrButton.svelte";
   import DsfrNavigation from "./DsfrNavigation.svelte";
   import DsfrSearch from "./DsfrSearch.svelte";
+  import { setIconClass, withIconsStyleSheet } from "$lib/utilitaires";
 
   type ButtonKind = Extract<Kind, "tertiary" | "tertiary-no-outline">;
+  type ToolLinkPreset =
+    | "close"
+    | "tooltip"
+    | "fullscreen"
+    | "display"
+    | "account"
+    | "team"
+    | "briefcase"
+    | "sort";
   type ToolLink = {
     label: string;
     url: string;
+    icon?: string;
+    preset?: ToolLinkPreset;
     classes?: string[];
     markup?: "a" | "button";
   };
@@ -190,6 +203,12 @@
   let openedMenuModal = $state(false);
   let openedSearchModal = $state(false);
 
+  function handleToolLinkClick(link: ToolLink) {
+    ($host() as HTMLElement).dispatchEvent(
+      new CustomEvent("toolLinkClick", { detail: link, bubbles: true, composed: true }),
+    );
+  }
+
   /**
    * Gère l'ouverture et la fermeture des modales du menu ou de la recherche dans le Header.
    *
@@ -231,6 +250,33 @@
     }
   });
 </script>
+
+{#snippet toolLinksRendered()}
+  {#if toolLinks?.length}
+    <ul class="fr-btns-group">
+      {#each toolLinks as link}
+        {@const { label, url, icon, preset, classes = [], markup = "a" } = link}
+        <li>
+          <svelte:element
+            this={markup}
+            href={markup === "a" ? url : undefined}
+            type={markup === "button" ? "button" : undefined}
+            role={markup === "button" ? "button" : undefined}
+            class={[
+              "fr-btn",
+              icon && setIconClass(icon),
+              preset && `fr-btn--${preset}`,
+              ...classes,
+            ]}
+            onclick={markup === "button" ? () => handleToolLinkClick(link) : undefined}
+          >
+            {label}
+          </svelte:element>
+        </li>
+      {/each}
+    </ul>
+  {/if}
+{/snippet}
 
 <svelte:element
   this={hasHeaderTag ? "header" : "div"}
@@ -318,7 +364,9 @@
             {#if hasToolLinks || hasTranslate}
               <div class="fr-header__tools-links">
                 <!-- Tool Links -->
-                <slot name="toolLinks"></slot>
+                <slot name="toolLinks">
+                  {@render toolLinksRendered()}
+                </slot>
 
                 <!-- Translate -->
                 <slot name="translate"></slot>
@@ -386,7 +434,9 @@
 
         {#if hasToolLinks}
           <div class="fr-header__menu-links">
-            <slot name="modalToolLinks"></slot>
+            <slot name="modalToolLinks">
+              {@render toolLinksRendered()}
+            </slot>
           </div>
         {/if}
 
@@ -411,6 +461,7 @@
   @import "@gouvfr/dsfr/src/dsfr/core/index";
   @import "@gouvfr/dsfr/src/dsfr/core/style/action/module";
   @import "@gouvfr/dsfr/src/dsfr/core/style/typography/module/paragraph";
+  @import "@gouvfr/dsfr/src/dsfr/core/style/typography/module/list";
   @import "@gouvfr/dsfr/src/dsfr/core/style/reset/module/box-sizing";
   @import "@gouvfr/dsfr/src/dsfr/core/style/reset/module/tap-highlight";
   @import "@gouvfr/dsfr/src/dsfr/core/style/icon/module";
@@ -422,6 +473,7 @@
   @import "@gouvfr/dsfr/dist/component/logo/logo.main.min.css";
   @import "@gouvfr/dsfr/dist/component/header/header.main.css";
   @import "@gouvfr/dsfr/dist/component/modal/modal.main.min.css";
+  @import "@gouvfr/dsfr/dist/component/button/button.main.css";
 
   @include set-shadow-host();
   @include set-dsfr-sizing("header") {

--- a/stories/dsfr/Header.stories.svelte
+++ b/stories/dsfr/Header.stories.svelte
@@ -10,10 +10,25 @@
   import PlaceholderPortrait from "@gouvfr/dsfr/example/img/placeholder.9x16.png";
 
   import DsfrHeader from "$lib/dsfr/DsfrHeader.svelte";
+
   // @ts-ignore: Required Import to use this component as webcomponent
   import DsfrBadge from "$lib/dsfr/DsfrBadge.svelte";
+
   // @ts-ignore: Required Import to use this component as webcomponent
   import DsfrButtonsGroup from "$lib/dsfr/DsfrButtonsGroup.svelte";
+
+  // @ts-ignore: Required Import to use this component as webcomponent
+  import Navigation from "$lib/composants/suite-cyber/navigation/Navigation.svelte";
+
+  // @ts-ignore: Required Import to use this component as webcomponent
+  import Bandeau from "$lib/composants/mes-services-cyber/bandeau/Bandeau.svelte";
+
+  // @ts-ignore: Required Import to use this component as webcomponent
+  import DsfrNavigation from "$lib/dsfr/DsfrNavigation.svelte";
+
+  // @ts-ignore: Required Import to use this component as webcomponent
+  import DsfrContainer from "$lib/dsfr/DsfrContainer.svelte";
+
   import webComponentSourceCode from "../utilitaires/webComponentSource.js";
 
   const { toolLinks } = headerArgs;
@@ -90,6 +105,251 @@
         },
       ],
       brandOperatorSrc: PlaceholderPortrait,
+      navItems: [
+        {
+          id: "navigation-01",
+          type: "menu",
+          active: true,
+          collapsable: true,
+          collapseId: "navigation-01",
+          label: "Intitulé menu",
+          items: [
+            {
+              id: "navigation-item-01-1",
+              type: "link",
+              active: false,
+              collapsable: false,
+              label: "Intitulé lien",
+              href: "#",
+            },
+            {
+              id: "navigation-item-01-2",
+              type: "link",
+              active: true,
+              collapsable: false,
+              label: "Intitulé lien",
+              href: "#",
+            },
+            {
+              id: "navigation-item-01-3",
+              type: "link",
+              active: false,
+              collapsable: false,
+              label: "Intitulé lien",
+              href: "#",
+            },
+          ],
+        },
+        {
+          id: "navigation-item-02",
+          type: "link",
+          active: false,
+          collapsable: false,
+          label: "Intitulé lien",
+          href: "#",
+        },
+        {
+          id: "navigation-03",
+          type: "menu",
+          active: false,
+          collapsable: true,
+          collapseId: "navigation-03",
+          label: "Intitulé menu",
+          items: [
+            {
+              id: "navigation-item-03-1",
+              type: "link",
+              active: false,
+              collapsable: false,
+              label: "Intitulé lien",
+              href: "#",
+            },
+            {
+              id: "navigation-03-2",
+              type: "menu",
+              active: false,
+              collapsable: true,
+              collapseId: "navigation-03-2",
+              label: "Intitulé menu",
+              items: [
+                {
+                  id: "navigation-item-03-2-1",
+                  type: "link",
+                  active: false,
+                  collapsable: false,
+                  label: "Intitulé lien",
+                  href: "#",
+                },
+                {
+                  id: "navigation-item-03-2-2",
+                  type: "link",
+                  active: false,
+                  collapsable: false,
+                  label: "Intitulé lien",
+                  href: "#",
+                },
+                {
+                  id: "navigation-item-03-2-3",
+                  type: "link",
+                  active: false,
+                  collapsable: false,
+                  label: "Intitulé lien",
+                  href: "#",
+                },
+              ],
+            },
+            {
+              id: "navigation-item-03-3",
+              type: "link",
+              active: false,
+              collapsable: false,
+              label: "Intitulé lien",
+              href: "#",
+            },
+          ],
+        },
+        {
+          id: "navigation-04",
+          type: "mega-menu",
+          active: false,
+          collapsable: true,
+          collapseId: "navigation-04",
+          label: "Intitulé mega menu",
+          close: "Fermer le menu",
+          leader: {
+            title: "Titre éditorialisé",
+            text: "Lorem ipsum dolor sit amet, consectetur adipiscing elit. Nullam id dolor id nibh ultricies vehicula ut id elit.",
+            link: {
+              id: "link-leader-04",
+              label: "Voir toute la rubrique",
+              iconPlace: "right",
+              icon: "arrow-right-line",
+            },
+          },
+          categories: [
+            {
+              label: "Catégorie 1",
+              href: "#",
+              items: [
+                {
+                  id: "navigation-item-04-1-1",
+                  type: "link",
+                  active: false,
+                  collapsable: false,
+                  label: "Intitulé lien",
+                  href: "#",
+                },
+                {
+                  id: "navigation-item-04-1-2",
+                  type: "link",
+                  active: false,
+                  collapsable: false,
+                  label: "Intitulé lien",
+                  href: "#",
+                },
+                {
+                  id: "navigation-item-04-1-3",
+                  type: "link",
+                  active: false,
+                  collapsable: false,
+                  label: "Intitulé lien",
+                  href: "#",
+                },
+              ],
+            },
+            {
+              label: "Catégorie 2",
+              href: "#",
+              items: [
+                {
+                  id: "navigation-item-04-2-1",
+                  type: "link",
+                  active: false,
+                  collapsable: false,
+                  label: "Intitulé lien",
+                  href: "#",
+                },
+                {
+                  id: "navigation-item-04-2-2",
+                  type: "link",
+                  active: false,
+                  collapsable: false,
+                  label: "Intitulé lien",
+                  href: "#",
+                },
+                {
+                  id: "navigation-item-04-2-3",
+                  type: "link",
+                  active: false,
+                  collapsable: false,
+                  label: "Intitulé lien",
+                  href: "#",
+                },
+              ],
+            },
+            {
+              label: "Catégorie 3",
+              href: "#",
+              items: [
+                {
+                  id: "navigation-item-04-3-1",
+                  type: "link",
+                  active: false,
+                  collapsable: false,
+                  label: "Intitulé lien",
+                  href: "#",
+                },
+                {
+                  id: "navigation-item-04-3-2",
+                  type: "link",
+                  active: false,
+                  collapsable: false,
+                  label: "Intitulé lien",
+                  href: "#",
+                },
+                {
+                  id: "navigation-item-04-3-3",
+                  type: "link",
+                  active: false,
+                  collapsable: false,
+                  label: "Intitulé lien",
+                  href: "#",
+                },
+              ],
+            },
+            {
+              label: "Catégorie 4",
+              href: "#",
+              items: [
+                {
+                  id: "navigation-item-04-4-1",
+                  type: "link",
+                  active: false,
+                  collapsable: false,
+                  label: "Intitulé lien",
+                  href: "#",
+                },
+                {
+                  id: "navigation-item-04-4-2",
+                  type: "link",
+                  active: false,
+                  collapsable: false,
+                  label: "Intitulé lien",
+                  href: "#",
+                },
+                {
+                  id: "navigation-item-04-4-3",
+                  type: "link",
+                  active: false,
+                  collapsable: false,
+                  label: "Intitulé lien",
+                  href: "#",
+                },
+              ],
+            },
+          ],
+        },
+      ],
     },
     parameters: {
       docs: {
@@ -151,8 +411,6 @@
 <Story name="Défaut" />
 
 <Story name="Avec Tool Links" args={{ hasSearch: undefined, hasToolLinks: true }} />
-<!-- <Story name="Défaut" args={{ hasToolLinks: undefined, hasTranslate: undefined }} />
-
 
 <Story name="Exemple - Header MQC">
   {#snippet template()}
@@ -169,4 +427,150 @@
       ></dsfr-badge>
     </dsfr-header>
   {/snippet}
-</Story> -->
+</Story>
+
+<Story
+  name="Exemple - Header MSS"
+  args={{
+    brandService: "",
+    hasBrandTagline: true,
+    brandTagline: "",
+    brandLogoTitle: "République<br>Française",
+    brandLinkId: "mss-brand-link",
+    hasBrandOperator: true,
+    brandOperatorAlt: "Logo ANSSI",
+    brandOperatorSrc: "https://upload.wikimedia.org/wikipedia/fr/3/31/Anssi.png",
+    brandOperatorStyle: "width: 64px",
+    hasToolLinks: true,
+    toolLinks: [
+      { label: "Inscription", url: "/" },
+      { label: "Connexion", url: "/", preset: "account" },
+    ],
+    hasNavigation: false,
+  }}
+>
+  {#snippet template(args: Args)}
+    <div class="mss-header-container">
+      <dsfr-header
+        id={args.id}
+        is-mourning={args.isMourning || undefined}
+        menu-id={args.menuId}
+        menu-modal-id={args.menuModalId}
+        has-tool-links={args.hasToolLinks || undefined}
+        tool-links={JSON.stringify(args.toolLinks)}
+        duplicate-tool-links={args.duplicateToolLinks || undefined}
+        has-translate={args.hasTranslate || undefined}
+        translate-id={args.translateId}
+        translate-collapse-id={args.translateCollapseId}
+        translate-button-title={args.translateButtonTitle}
+        translate-button-kind={args.translateButtonKind}
+        translate-languages={JSON.stringify(args.translateLanguages)}
+        has-search={args.hasSearch || undefined}
+        search-id={args.searchId}
+        search-modal-id={args.searchModalId}
+        search-btn-id={args.searchBtnId}
+        search-input-id={args.searchInputId}
+        search-label={args.searchLabel}
+        search-placeholder={args.searchPlaceholder}
+        search-title={args.searchTitle}
+        brand-logo-title={args.brandLogoTitle}
+        brand-service={args.brandService}
+        has-brand-tagline={args.hasBrandTagline || undefined}
+        brand-tagline={args.brandTagline}
+        brand-link-id={args.brandLinkId}
+        brand-link-title={args.brandLinkTitle}
+        brand-link-href={args.brandLinkHref}
+        has-brand-operator={args.hasBrandOperator || undefined}
+        brand-operator-alt={args.brandOperatorAlt}
+        brand-operator-src={args.brandOperatorSrc}
+        brand-operator-style={args.brandOperatorStyle}
+        has-navigation={args.hasNavigation || undefined}
+        navigation-id={args.navigationId}
+        navigation-aria-label={args.navigationAriaLabel}
+        navigation-items={JSON.stringify(args.navigationItems)}
+        has-header-tag={args.hasHeaderTag || undefined}
+        fluid={args.fluid || undefined}
+      >
+        <!-- Brand Operator -->
+        <div class="mss-brand-operator">
+          <a class="logo-anssi" href="https://cyber.gouv.fr" title="ANSSI"></a>
+          <a class="logo-mss" href="/" title="MonServiceSécurisé"></a>
+        </div>
+
+        <!-- A côté des tools links -->
+        <lab-anssi-bouton-suite-cyber-navigation
+          source-utm="mon-service-lab-anssi"
+          slot="beforetoolslinks"
+        ></lab-anssi-bouton-suite-cyber-navigation>
+
+        <!-- A côté du burger menu -->
+        <lab-anssi-bouton-suite-cyber-navigation
+          source-utm="mon-service-lab-anssi"
+          slot="beforenavbarbuttons"
+        ></lab-anssi-bouton-suite-cyber-navigation>
+      </dsfr-header>
+
+      <!-- Bandeau MSS -->
+      <lab-anssi-mes-services-cyber-bandeau affichage="visible"
+      ></lab-anssi-mes-services-cyber-bandeau>
+
+      <!-- Navigation DSFR -->
+      <dsfr-container>
+        <dsfr-navigation
+          id="navigation-mss"
+          aria-label="Navigation principale"
+          items={args.navItems}
+        ></dsfr-navigation>
+      </dsfr-container>
+    </div>
+
+    <style>
+      html,
+      body {
+        margin: 0;
+        padding: 0;
+      }
+
+      .mss-header-container {
+        background-color: var(--background-raised-grey);
+      }
+
+      :is(header nav a:not(.bouton), .logo-anssi, .logo-mss):hover {
+        background-color: var(--systeme-design-etat-gris-survol);
+      }
+
+      :is(header nav a, .logo-anssi, .logo-mss):active {
+        background-color: var(--systeme-design-etat-gris-actif);
+      }
+
+      .mss-brand-operator {
+        display: flex;
+        align-items: center;
+      }
+
+      .logo-anssi {
+        width: 4.05em;
+        height: 4.05em;
+        margin: 0 0.4em;
+        padding: 0.3em 0.85em;
+        background-image: url("https://s3.eu-west-par.io.cloud.ovh.net/sf-cyber/sf-cyber/images/20230704_np_anssi_logotype_500x500.original.png?X-Amz-Algorithm=AWS4-HMAC-SHA256&X-Amz-Credential=f56b12dc7d9741d6bb98766a26a6adca%2F20260413%2Feu-west-par%2Fs3%2Faws4_request&X-Amz-Date=20260413T064022Z&X-Amz-Expires=3600&X-Amz-SignedHeaders=host&X-Amz-Signature=e53259c5cfc7cda504db53b175cbc7efd7f540b936c92cd98fa3e9f1df90aac5");
+        background-origin: content-box;
+        background-repeat: no-repeat;
+        background-position: center;
+        background-size: contain;
+      }
+
+      .logo-mss {
+        width: 10.49em;
+        height: 3.7em;
+        margin-right: auto;
+        padding: 0.3em 0.85em;
+        background-image: url("https://raw.githubusercontent.com/betagouv/mon-service-securise/refs/heads/master/public/assets/images/logo_mss.svg");
+        background-origin: content-box;
+        background-repeat: no-repeat;
+        background-position: center;
+        background-size: contain;
+      }
+    </style>
+  {/snippet}
+</Story>

--- a/stories/dsfr/Header.stories.svelte
+++ b/stories/dsfr/Header.stories.svelte
@@ -23,8 +23,19 @@
     component: DsfrHeader,
     argTypes: {
       ...headerArgTypes,
+      beforenavbarbuttons: {
+        description:
+          "Contenu inséré avant les boutons de la barre de navigation mobile (recherche, menu)",
+        control: false,
+        table: { category: "Slots" },
+      },
       headerbadge: {
         description: "Badge affiché dans l'en-tête (ex : bêta, nouveau)",
+        control: false,
+        table: { category: "Slots" },
+      },
+      beforetoolslinks: {
+        description: "Contenu inséré avant les liens d'accès rapide dans la barre d'outils",
         control: false,
         table: { category: "Slots" },
       },

--- a/stories/dsfr/Header.stories.svelte
+++ b/stories/dsfr/Header.stories.svelte
@@ -71,6 +71,12 @@
           label: "Paramètres d'affichage",
           markup: "button",
         },
+        {
+          url: "#",
+          label: "Mon compte",
+          markup: "button",
+          icon: "account-circle-line",
+        },
       ],
       brandOperatorSrc: PlaceholderPortrait,
     },
@@ -94,7 +100,7 @@
     menu-id={args.menuId}
     menu-modal-id={args.menuModalId}
     has-tool-links={args.hasToolLinks || undefined}
-    tool-links={args.toolLinks}
+    tool-links={JSON.stringify(args.toolLinks)}
     duplicate-tool-links={args.duplicateToolLinks || undefined}
     has-translate={args.hasTranslate || undefined}
     translate-id={args.translateId}
@@ -128,59 +134,14 @@
     has-header-tag={args.hasHeaderTag || undefined}
     fluid={args.fluid || undefined}
   >
-    <!-- Tool Links -->
-    <dsfr-buttons-group
-      size="sm"
-      slot="toolLinks"
-      buttons={[
-        {
-          label: "Contact",
-          preset: "team",
-          href: "#",
-        },
-        {
-          label: "Espace recruteur",
-          preset: "briefcase",
-          href: "#",
-        },
-        {
-          label: "Espace compte",
-          preset: "account",
-          href: "#",
-        },
-      ]}
-      inline="true"
-      data-themeable="false"
-    ></dsfr-buttons-group>
-
-    <!-- Tool Links (modal) -->
-    <dsfr-buttons-group
-      slot="modalToolLinks"
-      buttons={[
-        {
-          label: "Contact",
-          preset: "team",
-          href: "#",
-        },
-        {
-          label: "Espace recruteur",
-          preset: "briefcase",
-          href: "#",
-        },
-        {
-          label: "Espace compte",
-          preset: "account",
-          href: "#",
-        },
-      ]}
-      data-themeable="false"
-    ></dsfr-buttons-group>
   </dsfr-header>
 {/snippet}
 
-<Story name="Défaut" args={{ hasToolLinks: undefined, hasTranslate: undefined }} />
+<Story name="Défaut" />
 
-<Story name="Avec Tool Links" args={{ hasSearch: undefined }} />
+<Story name="Avec Tool Links" args={{ hasSearch: undefined, hasToolLinks: true }} />
+<!-- <Story name="Défaut" args={{ hasToolLinks: undefined, hasTranslate: undefined }} />
+
 
 <Story name="Exemple - Header MQC">
   {#snippet template()}
@@ -197,4 +158,4 @@
       ></dsfr-badge>
     </dsfr-header>
   {/snippet}
-</Story>
+</Story> -->


### PR DESCRIPTION
## Décrire les changements

Cette PR effectue plusieurs évolutions afin d'améliorer le fonctionnement du composant `DsfrHeader`.
Ainsi, cette PR implémente : 

- La possibilité de gérer les **"tools links"** directement depuis la prop `toolLinks`, afin que ce groupe de boutons soit présent à la fois dans les zones dédiées en affichage desktop et mobile. Le slot `toolLinks` reste présent mais pour des usages avancées où on voudrait avoir un affichage différent sur desktop et sur mobile.
- L'ajout de deux nouveaux slots `beforenavbarbuttons` & `beforetoolslinks` qui permettent d'afficher du contenu avant les **"tools links"** en affichage desktop et avant le **"burger menu"** en affichage mobile.
- Une story d'exemple permettant de montrer le fonctionnement de tous ces éléments dans le cadre d'une reproduction du **Header MSS**.
