### PR TITLE
Revert "[NPM] Autorise à publier autrement qu'en `latest`"

### DIFF
--- a/.github/workflows/publication-npm.yml
+++ b/.github/workflows/publication-npm.yml
@@ -5,12 +5,6 @@ permissions:
 on:
   release:
     types: [published]
-  workflow_dispatch:
-    inputs:
-      npm_tag:
-        description: "Tag NPM à publier. Ne rien mettre pour publier en `latest`. Sinon utiliser le numéro de version, sans préfixe 'v'."
-        required: false
-        type: string
 
 jobs:
   publication:
@@ -48,7 +42,7 @@ jobs:
         run: pnpm run build:tokens && cp -r ./src/tokens/build/* ./dist/assets/
 
       - name: Publier sur NPM
-        run: pnpm publish --provenance --access public --no-git-checks ${{ github.event_name == 'workflow_dispatch' && inputs.npm_tag != '' && format('--tag {0}', inputs.npm_tag) || '' }}
+        run: pnpm publish --provenance --access public --no-git-checks
         env:
           NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
 


### PR DESCRIPTION
This reverts commit 2c438b690a7b476ec01c25fbeed1054251c03a27.

Maintenant que la `1.28.4` est publiée, on n'a plus besoin de ce comportement.
