### PR TITLE
[COMPOSANTS] DSFR - Mets à jour les appels à la mixin `set-shadow-host` pour inclure le nom des aux custom elements propre aux composants

### DIFF
--- a/src/lib/dsfr/DsfrButton.svelte
+++ b/src/lib/dsfr/DsfrButton.svelte
@@ -153,7 +153,7 @@
   // DSFR Component styles
   @import "@gouvfr/dsfr/dist/component/button/button.main.css";
 
-  @include set-shadow-host("inline-flex") {
+  @include set-shadow-host("inline-flex", $tag: "dsfr-button") {
     &:has(.fr-btn--centered) {
       --component-width: 100%;
       justify-content: center;

--- a/src/lib/dsfr/DsfrContainer.svelte
+++ b/src/lib/dsfr/DsfrContainer.svelte
@@ -27,7 +27,7 @@
   @import "@gouvfr/dsfr/src/dsfr/core/style/grid/module/container";
   @include grid($grid-settings);
 
-  @include set-shadow-host();
+  @include set-shadow-host($tag: "dsfr-container");
   @include set-dsfr-sizing("container");
   @include set-dsfr-sizing("container-fluid");
 </style>

--- a/src/lib/dsfr/DsfrLink.svelte
+++ b/src/lib/dsfr/DsfrLink.svelte
@@ -130,7 +130,7 @@
   // DSFR Component styles
   @import "@gouvfr/dsfr/src/dsfr/component/link/main";
 
-  @include set-shadow-host("inline", false);
+  @include set-shadow-host("inline", false, $tag: "dsfr-link");
   @include set-dsfr-sizing("link") {
     &--neutral {
       color: currentColor;

--- a/src/lib/dsfr/DsfrNavigation.svelte
+++ b/src/lib/dsfr/DsfrNavigation.svelte
@@ -128,7 +128,7 @@
   @import "@gouvfr/dsfr/src/dsfr/component/navigation/style/scheme";
   @include _navigation-scheme;
 
-  @include set-shadow-host("block");
+  @include set-shadow-host("block", $tag: "dsfr-navigation");
   @include set-dsfr-sizing("nav") {
     position: relative;
   }

--- a/src/lib/dsfr/DsfrPagination.svelte
+++ b/src/lib/dsfr/DsfrPagination.svelte
@@ -236,7 +236,7 @@
   // DSFR Component styles
   @import "@gouvfr/dsfr/dist/component/pagination/pagination.main.css";
 
-  @include set-shadow-host();
+  @include set-shadow-host($tag: "dsfr-pagination");
   @include set-dsfr-sizing("pagination") {
     &__link {
       @include set-border-radius();

--- a/src/lib/dsfr/DsfrSearch.svelte
+++ b/src/lib/dsfr/DsfrSearch.svelte
@@ -133,6 +133,6 @@
   @import "@gouvfr/dsfr/dist/component/button/button.main.css";
   @import "@gouvfr/dsfr/dist/component/search/search.main.css";
 
-  @include set-shadow-host();
+  @include set-shadow-host($tag: "dsfr-search");
   @include set-dsfr-sizing("search-bar");
 </style>

--- a/src/lib/dsfr/DsfrSelect.svelte
+++ b/src/lib/dsfr/DsfrSelect.svelte
@@ -170,7 +170,7 @@
   @import "@gouvfr/dsfr/dist/component/form/form.main.css";
   @import "@gouvfr/dsfr/dist/component/select/select.main.css";
 
-  @include set-shadow-host();
+  @include set-shadow-host($tag: "dsfr-select");
   @include set-dsfr-sizing("select-group") {
     &:has(.fr-sr-only) .fr-select {
       margin-top: 0;

--- a/src/lib/styles/mixins-dsfr.scss
+++ b/src/lib/styles/mixins-dsfr.scss
@@ -10,8 +10,14 @@ $checkmark-size: var(--checkmark-size, 24px) !default;
 /// @param {String} $display [block] - La valeur de la propriété CSS `display` à appliquer au `:host`.
 /// @content - Contenu CSS additionnel à insérer dans le bloc `:host`.
 ///
-@mixin set-shadow-host($display: "block", $font-size: true) {
-  :host {
+@mixin set-shadow-host($display: "block", $font-size: true, $tag: null) {
+  $host: ":host";
+
+  @if $tag {
+    $host: "#{$host}(#{$tag})";
+  }
+
+  #{$host} {
     display: #{$display};
     @include text-adjustments();
     @if $font-size {


### PR DESCRIPTION
## Décrire les changements

La mixin `set-shadow-host()` permet d'insérer des styles génériques qui doivent s'appliquer aux custom elements de l'UI Kit. Parmi ces styles, une propriété `display` est présente.

Le problème est que lorsque des composants sont imbriqués en Svelte, le code CSS final contient plusieurs propriétés `:host` qui entrent en conflit. 

Afin de palier à ce problème cette PR effectue l'évolution de la mixin `set-shadow-host` afin d'ajouter de façon spécifique dans la propriété `:host` le nom du custom element dans le but d'éviter les conflits.

## Autres informations

<!-- Ajoutez ici tout autre commentaire ou toute autre information concernant cette Pull Request. -->
