### PR TITLE
Améliore la lisibilité des descriptions des slots dans les stories

### DIFF
--- a/stories/composants/Marelle.stories.svelte
+++ b/stories/composants/Marelle.stories.svelte
@@ -73,7 +73,8 @@
         table: { category: "Slots" },
       },
       default: {
-        description: "Étapes personnalisées (remplace les étapes générées par la prop `etapesmarelle`)",
+        description:
+          "Étapes personnalisées (remplace les étapes générées par la prop `etapesmarelle`)",
         control: false,
         table: { category: "Slots" },
       },
@@ -83,12 +84,14 @@
         table: { category: "Slots (Etape)" },
       },
       "etape-description": {
-        description: "Description personnalisée de chaque étape (remplace la prop `description` de l'étape)",
+        description:
+          "Description personnalisée de chaque étape (remplace la prop `description` de l'étape)",
         control: false,
         table: { category: "Slots (Etape)" },
       },
       "etape-lien": {
-        description: "Lien personnalisé de chaque étape (remplace le lien généré par la prop `lien` de l'étape)",
+        description:
+          "Lien personnalisé de chaque étape (remplace le lien généré par la prop `lien` de l'étape)",
         control: false,
         table: { category: "Slots (Etape)" },
       },

--- a/stories/dsfr/Content.stories.svelte
+++ b/stories/dsfr/Content.stories.svelte
@@ -55,7 +55,8 @@
         table: { category: "Slots" },
       },
       video: {
-        description: "Élément vidéo personnalisé (remplace le rendu par défaut quand `type='video'`)",
+        description:
+          "Élément vidéo personnalisé (remplace le rendu par défaut quand `type='video'`)",
         control: false,
         table: { category: "Slots" },
       },

--- a/stories/dsfr/Select.stories.svelte
+++ b/stories/dsfr/Select.stories.svelte
@@ -33,7 +33,8 @@
         table: { category: "message" },
       },
       default: {
-        description: "Options `<option>` personnalisées (remplace les options générées par la prop `options`)",
+        description:
+          "Options `<option>` personnalisées (remplace les options générées par la prop `options`)",
         control: false,
         table: { category: "Slots" },
       },


### PR DESCRIPTION
## Décrire les changements

Cette PR améliore le formatage de certaines stories en lançant la commande : `npx prettier -w .`.

## Autres informations

<!-- Ajoutez ici tout autre commentaire ou toute autre information concernant cette Pull Request. -->
