### PR TITLE
[COMPOSANTS] Lab - Ajoute l'héritage de la police dans les éléments button & select

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@lab-anssi/ui-kit",
-  "version": "1.47.0",
+  "version": "1.47.1",
   "repository": {
     "type": "git",
     "url": "git+https://github.com/betagouv/lab-anssi-ui-kit.git"

--- a/src/lib/composants/CentreAide.svelte
+++ b/src/lib/composants/CentreAide.svelte
@@ -116,6 +116,7 @@
     padding: 10px 24px 10px 18px;
     cursor: pointer;
     z-index: 1000;
+    font-family: inherit;
 
     &:hover {
       background: $centre-aide-background-hover-declencheur;

--- a/src/lib/composants/Tag.svelte
+++ b/src/lib/composants/Tag.svelte
@@ -95,6 +95,8 @@
     text-wrap: auto;
     text-align: left;
     cursor: pointer;
+    font-family: inherit;
+
     &:hover {
       background-color: $tag-selectionnable-couleur-fond-survol;
     }

--- a/src/lib/composants/blog/BandeauTitre.svelte
+++ b/src/lib/composants/blog/BandeauTitre.svelte
@@ -137,6 +137,7 @@
           background: none;
           margin: 0;
           padding: 0;
+          font-family: inherit;
         }
 
         button,

--- a/src/lib/composants/blog/ListeDeroulante.svelte
+++ b/src/lib/composants/blog/ListeDeroulante.svelte
@@ -51,6 +51,7 @@
       line-height: 1.5rem;
       background: #eeeeee;
       max-width: 100%;
+      font-family: inherit;
 
       &:hover {
         background: $background-default-grey-hover;

--- a/src/lib/composants/vitrines-produits/briques/CarrouselTuiles/CarrouselTuiles.svelte
+++ b/src/lib/composants/vitrines-produits/briques/CarrouselTuiles/CarrouselTuiles.svelte
@@ -116,6 +116,7 @@
     display: flex;
     align-items: center;
     gap: 8px;
+    font-family: inherit;
 
     &:hover {
       &:after {

--- a/src/lib/composants/vitrines-produits/briques/temoignages/Temoignages.svelte
+++ b/src/lib/composants/vitrines-produits/briques/temoignages/Temoignages.svelte
@@ -192,6 +192,7 @@
           display: flex;
           align-items: center;
           gap: 8px;
+          font-family: inherit;
 
           &:hover {
             &:after {

--- a/src/lib/styles/apparence-bouton.scss
+++ b/src/lib/styles/apparence-bouton.scss
@@ -7,9 +7,9 @@
   cursor: pointer;
   justify-content: center;
   text-align: center;
-
   font-style: normal;
   font-weight: 500;
+  font-family: inherit;
 
   &.largeur-maximale {
     width: 100%;


### PR DESCRIPTION
## Décrire les changements

Les styles navigateurs affectent une redéfinition de la propriété `font-family` sur les éléments `button` & `select`, ce qui empêche l'application de la police "Marianne" tel que souhaité.

Cette PR, redéfini la propriété `font-family` sur ces éléments et lui affecte la valeur de `inherit` afin que ces éléments puissent bénéficier de la cascade CSS sur la propriété `font-family`.

## Autres informations

<!-- Ajoutez ici tout autre commentaire ou toute autre information concernant cette Pull Request. -->
