### PR TITLE
[COMPOSANT] DsfrTabs - Améliore le mode de calcul de la hauteur des onglets

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@lab-anssi/ui-kit",
-  "version": "1.47.1",
+  "version": "1.47.2",
   "repository": {
     "type": "git",
     "url": "git+https://github.com/betagouv/lab-anssi-ui-kit.git"

--- a/src/lib/dsfr/DsfrTabs.svelte
+++ b/src/lib/dsfr/DsfrTabs.svelte
@@ -82,9 +82,16 @@
     const panel = panelEls[activeIndex];
     if (!tabsElement || !panel || !tabsListElement) return;
 
-    const panelHeight = panel.offsetHeight;
-    const listHeight = tabsListElement.offsetHeight;
-    tabsElement.style.setProperty("--tabs-height", `${panelHeight + listHeight - 4}px`);
+    const updateHeight = () => {
+      const panelHeight = panel.offsetHeight;
+      const listHeight = tabsListElement!.offsetHeight;
+      tabsElement!.style.setProperty("--tabs-height", `${panelHeight + listHeight - 4}px`);
+    };
+
+    const observer = new ResizeObserver(updateHeight);
+    observer.observe(panel);
+
+    return () => observer.disconnect();
   });
 
   /**

--- a/stories/dsfr/Tabs.stories.svelte
+++ b/stories/dsfr/Tabs.stories.svelte
@@ -10,6 +10,8 @@
 
   import DsfrTabs from "$lib/dsfr/DsfrTabs.svelte";
   import DsfrBadge from "$lib/dsfr/DsfrBadge.svelte";
+  import DsfrButton from "$lib/dsfr/DsfrButton.svelte";
+  import DsfrCard from "$lib/dsfr/DsfrCard.svelte";
   import webComponentSourceCode from "../utilitaires/webComponentSource.js";
 
   const { Story } = defineMeta({
@@ -90,12 +92,43 @@
           </span>
         </span>
         <div slot={`panel-${i + 1}`}>
-          <p>
-            <strong>
-              Contenu de l'onglet <dsfr-badge label={i + 1} type="accent" accent="green-archipel"
-              ></dsfr-badge>
-            </strong>
-          </p>
+          <div class="container-avec-cadre">
+            <p>
+              <strong>
+                Contenu de l'onglet <dsfr-badge label={i + 1} type="accent" accent="green-archipel"
+                ></dsfr-badge>
+              </strong>
+            </p>
+            {#if i === 0}
+              <div class="card-container">
+                {#each Array(10) as _, j}
+                  <dsfr-card
+                    title={`Intitulé de la carte ${j + 1}`}
+                    description="Lorem ipsum dolor sit amet, consectetur adipiscing, incididunt, ut labore et dolore magna aliqua. Vitae sapien pellentesque habitant morbi tristique senectus et"
+                    detail-start="détail (optionnel)"
+                    detail-start-icon="warning-fill"
+                    detail-end="détail (optionnel)"
+                    detail-end-icon="warning-fill"
+                    markup="h3"
+                    action-markup="a"
+                    href="[URL - à modifier]"
+                    size="md"
+                    src="https://betagouv.github.io/lab-anssi-ui-kit/assets/placeholder.16x9-BgJU1mfU.png"
+                    alt="[À MODIFIER - vide ou texte alternatif de l’image]"
+                    image-ratio="default"
+                    variations="none"
+                    has-description
+                    enlarge
+                    horizontal
+                  ></dsfr-card>
+                {/each}
+              </div>
+            {/if}
+
+            <dsfr-button class="fr-mt-2w" size="sm" variant="secondary">
+              Action de l'onglet {i + 1}
+            </dsfr-button>
+          </div>
         </div>
       {/each}
     </dsfr-tabs>
@@ -121,6 +154,12 @@
           background-color: var(--border-active-blue-france);
           color: white;
         }
+      }
+
+      .card-container {
+        display: flex;
+        gap: 2rem;
+        flex-direction: column;
       }
     </style>
   {/snippet}


### PR DESCRIPTION
## Décrire les changements

La hauteur des onglets est définie par la custom property `--tabs-height`.
Précédemment, le calcul de cette hauteur était effectué de façon simple dans un `$effect` svelte.

Cependant, `$effect` s'exécute la première fois lorsque le composant est intégré au DOM.

Hors dans le cadre d'un **tabpanel** contenant des **WebComponents**, il se peut que le navigateur n'ai pas fini de construire le layout au moment du montage du composant, ce qui engendre dans certains cas un calcul erroné de la hauteur.

Pour palier à ce problème, cette PR fait évoluer la façon de calculer la hauteur du des **tabpanels**, en ajoutant un `ResizeObserver` dans le `$effect` de telle sorte à ce que la hauteur soit recalculée lors de toute évolution du DOM sur cette zone.

## Liens additionnels

- https://svelte.dev/docs/svelte/$effect#Understanding-lifecycle
- https://developer.mozilla.org/en-US/docs/Web/API/ResizeObserver