### PR TITLE
[COMPOSANT] DsfrButton - Rendre la prop `label` du bouton optionnel

### DIFF
--- a/src/lib/dsfr/DsfrButton.svelte
+++ b/src/lib/dsfr/DsfrButton.svelte
@@ -31,7 +31,7 @@
   type ButtonSize = Extract<Size, "sm" | "md" | "lg">;
   interface Props {
     /** Libellé du bouton */
-    label: string;
+    label?: string;
     /** Type du bouton */
     kind?: Kind;
     /** Taille du bouton */


### PR DESCRIPTION
## Décrire les changements

Rendre la prop `label` du bouton optionnel.

## Autres informations

<!-- Ajoutez ici tout autre commentaire ou toute autre information concernant cette Pull Request. -->
