### PR TITLE
[STORYBOOK] DsfrButtonsGroup - Corrige le passage de la prop `inline` au composant

### DIFF
--- a/stories/dsfr/ButtonsGroup.stories.svelte
+++ b/stories/dsfr/ButtonsGroup.stories.svelte
@@ -56,7 +56,7 @@
     has-icon={args.hasIcon}
     icon-place={args.iconPlace}
     group-markup={args.groupMarkup}
-    inline={args.inline}
+    inline={`${args.inline}`}
     equisized={args.equisized || undefined}
     align={args.align}
     reverse={args.reverse || undefined}


### PR DESCRIPTION
## Décrire les changements

`DsfrButtonsGroup` - Corrige le passage de la prop `inline` au composant.

## Autres informations

<!-- Ajoutez ici tout autre commentaire ou toute autre information concernant cette Pull Request. -->
