### PR TITLE
[STYLES] Ajoute des styles de fallback pour le conteneur dsfr

### DIFF
--- a/src/lib/styles/dsfr-variables.scss
+++ b/src/lib/styles/dsfr-variables.scss
@@ -13,3 +13,11 @@
 
   --text-decoration: none;
 }
+
+dsfr-container:not(:defined) {
+  display: block;
+  margin: 0 auto;
+  max-width: 78rem;
+  padding-inline: 1rem;
+  width: 100%;
+}


### PR DESCRIPTION
## Décrire les changements

Afin d'éviter le "shift" de layout lors du chargement des composants en provenance du l'UI Kit, cette PR ajoute des styles de fallback pour le conteneur dsfr.

## Autres informations

<!-- Ajoutez ici tout autre commentaire ou toute autre information concernant cette Pull Request. -->
