### PR TITLE
[COMPOSANT] DsfrCard - Usage des slots `image` et `contentend`

### DIFF
--- a/src/lib/dsfr/DsfrCard.svelte
+++ b/src/lib/dsfr/DsfrCard.svelte
@@ -252,10 +252,12 @@
       </div>
     {/if}
   </div>
-  {#if src}
+  {#if src || $$slots.image}
     <div class="fr-card__header">
       <div class="fr-card__img">
-        <img class={["fr-responsive-img", imageRatioClass]} {src} {alt} />
+        <slot name="image">
+          <img class={["fr-responsive-img", imageRatioClass]} {src} {alt} />
+        </slot>
       </div>
       {#if hasHeaderBadge}
         <slot name="headerbadges" />

--- a/src/lib/dsfr/DsfrCard.svelte
+++ b/src/lib/dsfr/DsfrCard.svelte
@@ -234,10 +234,11 @@
       {/if}
       {#if hasDetailEnd}
         <div class="fr-card__end">
+          <slot name="contentend" />
+
           {#if detailEnd}
             <p class={["fr-card__detail", detailEndIconClass]}>{detailEnd}</p>
           {/if}
-          <slot name="contentend" />
         </div>
       {/if}
     </div>

--- a/stories/dsfr/Card.stories.svelte
+++ b/stories/dsfr/Card.stories.svelte
@@ -7,6 +7,8 @@
     cardArgTypes,
   } from "@gouvfr/dsfr/src/dsfr/component/card/template/stories/card-arg-types.js";
   import Placeholder from "@gouvfr/dsfr/example/img/placeholder.16x9.png";
+  import Placeholder1x1 from "@gouvfr/dsfr/example/img/placeholder.1x1.png";
+  import Placeholder3x4 from "@gouvfr/dsfr/example/img/placeholder.3x4.png";
 
   import DsfrCard from "$lib/dsfr/DsfrCard.svelte";
   // @ts-ignore: Required Import to use this component as webcomponent
@@ -48,6 +50,12 @@
       },
       headerbadges: {
         description: "Badges superposés à l'image d'en-tête",
+        control: false,
+        table: { category: "Slots" },
+      },
+      image: {
+        description:
+          "Permet d'utiliser une image personnalisée (ex. <picture>, <svg>, ou <img>) en remplacement de l'image par défaut et des styles associées",
         control: false,
         table: { category: "Slots" },
       },
@@ -176,3 +184,30 @@
     size: "sm",
   }}
 />
+
+<Story name="Avec slot image personnalisé">
+  {#snippet template(args: Args)}
+    <dsfr-card
+      title={args.title}
+      has-description={args.hasDescription || undefined}
+      description={args.description}
+      action-title={args.actionTitle}
+      href={args.href}
+      size={args.size}
+    >
+      <picture slot="image">
+        <source media="(min-width: 48em)" srcset={Placeholder} />
+        <source media="(min-width: 36em)" srcset={Placeholder3x4} />
+        <img class="custom-image" src={Placeholder1x1} alt="Illustration personnalisée" />
+      </picture>
+    </dsfr-card>
+
+    <style>
+      .custom-image {
+        max-width: 100%;
+        object-fit: cover;
+        height: auto;
+      }
+    </style>
+  {/snippet}
+</Story>


### PR DESCRIPTION
## Décrire les changements

Cette PR ajoute un nouveau slot nommé `image` permettant de remplacer l'image par défaut ainsi que les styles associées. 
L'ajout de ce slot, laisse à présent à l'utilisateur la liberté de définir une nouvelle balise `img` avec des styles spécifiques et des ratios convenant le mieux à son interface.

La PR inverse également la position du slot `contentend` afin d'obtenir un affichage ISO à [la maquette Figma](https://www.figma.com/design/xMHWnVuEfQRiPhPYwFMPxF/MSC_Plateforme?node-id=14466-61465&t=hDAKsU23VcO6RV4A-4).