### PR TITLE
[FOOTER] Rends l'attribut contentDescription optionnel

### DIFF
--- a/src/lib/dsfr/DsfrFooter.svelte
+++ b/src/lib/dsfr/DsfrFooter.svelte
@@ -185,10 +185,10 @@
           {/if}
         </div>
         <div class="fr-footer__content">
-          {#if hasDescription && contentDescription}
+          {#if hasDescription}
             {#if $$slots.description}
               <slot name="description"></slot>
-            {:else}
+            {:else if contentDescription}
               <p class="fr-footer__content-desc">
                 {@html contentDescription}
               </p>


### PR DESCRIPTION
## Décrire les changements

Évite de devoir valoriser l'attribut `contentDescription` du `DsfrFooter` lorsqu'on utilise le slot

## Cette PR introduit-elle un "breaking change" ?

- [ ] Yes
- [x] No