### PR TITLE
Personnalisation dsfr header

### DIFF
--- a/src/lib/dsfr/DsfrHeader.svelte
+++ b/src/lib/dsfr/DsfrHeader.svelte
@@ -47,10 +47,10 @@
 
 <script lang="ts">
   import type { Kind, TranslateLanguage } from "$lib/types";
+  import { setIconClass, withIconsStyleSheet } from "$lib/utilitaires";
   import DsfrButton from "./DsfrButton.svelte";
   import DsfrNavigation from "./DsfrNavigation.svelte";
   import DsfrSearch from "./DsfrSearch.svelte";
-  import { setIconClass, withIconsStyleSheet } from "$lib/utilitaires";
 
   type ButtonKind = Extract<Kind, "tertiary" | "tertiary-no-outline">;
   type ToolLinkPreset =
@@ -443,6 +443,7 @@
             <slot name="modalToolLinks">
               {@render toolLinksRendered()}
             </slot>
+            <slot name="aftermodaltoollinks"></slot>
           </div>
         {/if}
 

--- a/src/lib/dsfr/DsfrNavigation.svelte
+++ b/src/lib/dsfr/DsfrNavigation.svelte
@@ -109,6 +109,11 @@
           {/if}
         </li>
       {/each}
+      {#if $$slots.afternavigation}
+        <li class="fr-nav__item">
+          <slot name="afternavigation"></slot>
+        </li>
+      {/if}
     </ul>
   {/if}
 </nav>


### PR DESCRIPTION
## Décrire les changements

- Ajoute la possibilité de mettre un élément à droite de la navigation (en mode bureau)
- Ajoute la possibilité de mettre un élément entre les liens et la navigation (en mode mobile et tablette)

## Cette PR introduit-elle un "breaking change" ?

- [ ] Yes
- [x] No

