### PR TITLE
[THEME] Améliorer le sélecteur [data-themeable] pour les thèmes

### DIFF
--- a/.storybook/lab-anssi-themes.css
+++ b/.storybook/lab-anssi-themes.css
@@ -148,7 +148,7 @@
   --lab-border-radius: var(--bouton-arrondi);
 }
 
-.theme-msc [data-themeable] {
+.theme-msc [data-themeable="true"] {
   --background-alt-blue-france: var(--yellow-msc-50);
   --background-action-high-blue-france: var(--yellow-msc-200);
   --background-action-high-blue-france-hover: var(--yellow-msc-250);
@@ -256,7 +256,7 @@
   --lab-border-radius: var(--bouton-arrondi);
 }
 
-.theme-mss [data-themeable] {
+.theme-mss [data-themeable="true"] {
   --background-alt-blue-france: var(--blue-mss-50);
   --background-action-high-blue-france: var(--blue-mss-600);
   --background-action-high-blue-france-hover: var(--blue-mss-700);

--- a/docs/thematisation.md
+++ b/docs/thematisation.md
@@ -7,6 +7,7 @@
 - [Définition des tokens](#définition-des-tokens)
 - [Génération des styles avec Style Dictionary](#génération-des-styles-avec-style-dictionary)
 - [Intégration dans les composants Svelte](#intégration-dans-les-composants-svelte)
+- [Désactiver la thématisation d'un composant](#désactiver-la-thématisation-dun-composant)
 - [Mixins SCSS](#mixins-scss)
 - [Visualisation dans Storybook](#visualisation-dans-storybook)
 - [Scripts de build](#scripts-de-build)
@@ -218,6 +219,45 @@ Elle ajoute l'attribut `data-themeable="true"` sur l'élément hôte du Web Comp
 
 L'appel à `setThemeable($host())` se fait dans la section `<script>` du composant.<br/>
 `$host()` est [une API Svelte](https://svelte.dev/docs/svelte/host) qui retourne l'élément hôte du Custom Element.
+
+---
+
+## Désactiver la thématisation d'un composant
+
+Certains composants doivent conserver l'identité visuelle native du DSFR sans être surchargés par les thèmes du Lab. C'est notamment le cas du `DsfrHeader` et du `DsfrFooter`, dont l'apparence institutionnelle ne doit pas varier d'un produit à l'autre.
+
+Le système de thématisation prévoit deux mécanismes complémentaires pour exclure un élément de la thématisation, tous deux basés sur l'attribut `data-themeable="false"`.
+
+### 1. Au niveau du composant (Svelte)
+
+La fonction `setThemeable` accepte un second paramètre `active` _(par défaut `true`)_.<br/>
+En passant `false`, le composant déclare explicitement qu'il ne doit pas être thématisé :
+
+```svelte
+<script lang="ts">
+  import { setThemeable } from "$lib/utilitaires";
+
+  setThemeable($host(), false);
+</script>
+```
+
+L'élément hôte du Web Component reçoit alors l'attribut `data-themeable="false"`, et les surcharges issues du thème actif ne s'y appliquent pas.
+
+C'est l'approche utilisée par défaut pour les composants `DsfrHeader` ou `DsfrFooter` par exemple.
+
+### 2. Au niveau du consommateur (HTML)
+
+Une application qui consomme la librairie peut également désactiver la thématisation d'un composant en plaçant l'attribut `data-themeable="false"` directement sur l'élément :
+
+```html
+<dsfr-button data-themeable="false">Bouton institutionnel</dsfr-button>
+```
+
+Lorsque `setThemeable` est appelée par le composant, elle détecte la présence de `data-themeable="false"` sur l'hôte et **ne modifie pas la valeur**. Le choix du consommateur est donc prioritaire sur la valeur par défaut du composant : un composant déclaré thématisable peut être désactivé localement sans modification du code source.
+
+### Restitution des couleurs DSFR
+
+Pour qu'un composant non thématisable affiche les couleurs natives du DSFR — et non celles d'un thème actif sur un conteneur parent — le fichier [`src/lib/styles/dsfr-variables.scss`](../src/lib/styles/dsfr-variables.scss) ajoute le selecteur `[data-themeable="false"]` au sélecteur `:root` initial qui définit l'ensemble des variables de couleurs DSFR.
 
 ---
 

--- a/docs/thematisation.md
+++ b/docs/thematisation.md
@@ -31,7 +31,7 @@ Chaque produit du Lab ANSSI dispose de son propre thème :
 
 Le principe est le suivant :
 
-1. Les composants s'appuient sur des variables CSS.\*\*\*\*
+1. Les composants s'appuient sur des variables CSS.
 2. Ces variables CSS sont disponibles dans des fichiers `.css` générés à partir de fichiers `.json` de **design tokens**.
 3. Le système de thématisation **surcharge ces variables** avec les couleurs propres à chaque produit, permettant ainsi aux composants de changer d'apparence sans modifier leur code source.
 
@@ -69,7 +69,7 @@ Le workflow global est le suivant :
 flowchart TD
   A["Tokens JSON <br/> (primitives + thèmes)"] --> B["Style Dictionary <br/> (build.config.ts)"]
   B --> C["Fichiers CSS générés <br/> par thème"]
-  C --> D["Composants Svelte thémé à l'aide de l'attribut [data-themeable]"]
+  C --> D["Composants personnalisés à l'aide de l'attribut [data-themeable='true']"]
   D --> E["Rendu visuel thématisé"]
 ```
 
@@ -112,9 +112,9 @@ Ce sont des tokens propres à chaque produit. Ils sont générés dans le sélec
 }
 ```
 
-#### 2. Tokens DSFR thématisables (`[data-themeable]`)
+#### 2. Tokens DSFR thématisables (`[data-themeable="true"]`)
 
-Ces tokens surchargent les variables CSS du DSFR.<br/> Ils sont identifiés par la propriété `"$themeable": true` et sont générés dans le sélecteur `[data-themeable]`.
+Ces tokens surchargent les variables CSS du DSFR.<br/> Ils sont identifiés par la propriété `"$themeable": true` et sont générés dans le sélecteur `[data-themeable"true"]`.
 
 ```json
 {
@@ -137,7 +137,7 @@ Ces tokens surchargent les variables CSS du DSFR.<br/> Ils sont identifiés par 
 }
 ```
 
-Les catégories de variables DSFR surchargées sont :
+##### Les catégories de variables DSFR surchargées sont :
 
 | Catégorie    | Variables concernées                                                                                                                   |
 | ------------ | -------------------------------------------------------------------------------------------------------------------------------------- |
@@ -159,7 +159,7 @@ La transformation des tokens JSON en variables CSS est assurée par [Style Dicti
 Ce format sépare les tokens générés en deux blocs CSS :
 
 - Les tokens **sans** `$themeable` sont placés dans le sélecteur `:root`
-- Les tokens **avec** `$themeable: true` sont placés dans le sélecteur `[data-themeable]`
+- Les tokens **avec** `$themeable: true` sont placés dans le sélecteur `[data-themeable="true"]`
 
 ```css
 /* Exemple de sortie pour le thème MSC */
@@ -168,7 +168,7 @@ Ce format sépare les tokens générés en deux blocs CSS :
   --bouton-primaire-couleur-fond: var(--yellow-msc-200);
 }
 
-[data-themeable] {
+[data-themeable="true"] {
   --background-action-high-blue-france: var(--yellow-msc-200);
   --text-action-high-blue-france: var(--midnight-blue-msc-950);
 }
@@ -181,7 +181,7 @@ Les références internes au thème sont préservées sous forme de `var(...)` (
 Après la génération de chaque fichier de thème individuel, cette action :
 
 1. Remplace `:root` par `.theme-{CIGLE-DU-THEME}` (ex. `.theme-msc`)
-2. Remplace `[data-themeable]` par `.theme-{CIGLE-DU-THEME} [data-themeable]`
+2. Remplace `[data-themeable="true"]` par `.theme-{CIGLE-DU-THEME} [data-themeable="true"]`
 3. Concatène le résultat dans `.storybook/lab-anssi-themes.css`
 
 Ce fichier combiné permet le basculement de thèmes dans Storybook via des classes CSS.
@@ -204,7 +204,7 @@ Ce fichier combiné permet le basculement de thèmes dans Storybook via des clas
 
 Définie dans `src/lib/utilitaires/index.ts`, cette fonction marque un Web Component comme thématisable.
 
-Elle ajoute l'attribut `data-themeable="true"` sur l'élément hôte du Web Component.<br/> Cet attribut est clé dans ce système : les variables CSS thématisées ne s'appliquent qu'aux éléments portant cet attribut (via le sélecteur `[data-themeable]`).
+Elle ajoute l'attribut `data-themeable="true"` sur l'élément hôte du Web Component.<br/> Cet attribut est clé dans ce système : les variables CSS thématisées ne s'appliquent qu'aux éléments portant cet attribut (via le sélecteur `[data-themeable="true"]`).
 
 ### Usage dans un composant
 
@@ -301,7 +301,7 @@ decorators: [
 1. L'utilisateur sélectionne un thème dans la barre d'outils Storybook
 2. L'addon applique la classe correspondante (ex. `theme-msc`) sur le conteneur
 3. Les variables CSS du thème sélectionné sont appliquées en cascade
-4. Les composants avec `[data-themeable]` reçoivent les surcharges DSFR
+4. Les composants avec `[data-themeable="true"]` reçoivent les surcharges DSFR
 
 ---
 

--- a/src/lib/dsfr/DsfrFooter.svelte
+++ b/src/lib/dsfr/DsfrFooter.svelte
@@ -29,6 +29,10 @@
 />
 
 <script lang="ts">
+  import { setThemeable } from "$lib/utilitaires";
+
+  setThemeable($host(), false);
+
   type ContentLink = {
     label: string;
     href: string;

--- a/src/lib/dsfr/DsfrHeader.svelte
+++ b/src/lib/dsfr/DsfrHeader.svelte
@@ -47,10 +47,12 @@
 
 <script lang="ts">
   import type { Kind, TranslateLanguage } from "$lib/types";
-  import { setIconClass, withIconsStyleSheet } from "$lib/utilitaires";
+  import { setIconClass, withIconsStyleSheet, setThemeable } from "$lib/utilitaires";
   import DsfrButton from "./DsfrButton.svelte";
   import DsfrNavigation from "./DsfrNavigation.svelte";
   import DsfrSearch from "./DsfrSearch.svelte";
+
+  setThemeable($host(), false);
 
   type ButtonKind = Extract<Kind, "tertiary" | "tertiary-no-outline">;
   type ToolLinkPreset =

--- a/src/lib/styles/dsfr-variables.scss
+++ b/src/lib/styles/dsfr-variables.scss
@@ -1,3 +1,4 @@
+@use "@gouvfr/dsfr/src/module/color";
 @import "@gouvfr/dsfr/src/dsfr/core/index";
 @import "@gouvfr/dsfr/src/dsfr/core/style/display/module/no-scroll";
 @import "@gouvfr/dsfr/src/dsfr/core/style/spacing/module/elevation";
@@ -12,6 +13,10 @@
   @include enable-external;
 
   --text-decoration: none;
+}
+
+[data-themeable="false"] {
+  @include color.define();
 }
 
 dsfr-container:not(:defined) {

--- a/src/lib/utilitaires/index.ts
+++ b/src/lib/utilitaires/index.ts
@@ -18,13 +18,14 @@ export function setIconClass(icon: string): string | undefined {
  * Marque un Web Component comme thématisable via l'attribut data-themeable
  * Permet d'appliquer des styles conditionnels basés sur cet attribut
  * @param {HTMLElement | undefined} host - L'élément host du Web Component ($host)
+ * @param {boolean} [active=true] - Indique si le thème est actif ou non
  */
-export function setThemeable(host: HTMLElement | undefined): void {
-  if (host?.hasAttribute("data-themeable") && host.getAttribute("data-themeable") === "false") {
-    host.removeAttribute("data-themeable");
 
+export function setThemeable(host: HTMLElement | undefined, active: boolean = true): void {
+  if (!host) return;
+
+  if (host.hasAttribute("data-themeable") && host.getAttribute("data-themeable") === "false")
     return;
-  }
 
-  host?.setAttribute("data-themeable", "true");
+  host.setAttribute("data-themeable", active ? "true" : "false");
 }

--- a/src/tokens/build.config.ts
+++ b/src/tokens/build.config.ts
@@ -67,8 +67,8 @@ function estThemable(token: TransformedToken): boolean {
 }
 
 /**
- * Format CSS avec sélecteur :root et [data-themeable] (pour consommateurs finaux)
- * Les tokens avec $themeable: true vont dans [data-themeable]
+ * Format CSS avec sélecteur :root et [data-themeable="true"] (pour consommateurs finaux)
+ * Les tokens avec $themeable: true vont dans [data-themeable="true"]
  * Les autres tokens vont dans :root
  */
 StyleDictionary.registerFormat({
@@ -105,7 +105,7 @@ StyleDictionary.registerFormat({
     }
 
     if (variablesThemables.length > 0) {
-      contenuCss += `\n[data-themeable] {\n${variablesThemables.join("\n")}\n}\n`;
+      contenuCss += `\n[data-themeable="true"] {\n${variablesThemables.join("\n")}\n}\n`;
     }
 
     return contenuCss;
@@ -114,7 +114,7 @@ StyleDictionary.registerFormat({
 
 /**
  * Action qui s'exécute après la génération des fichiers
- * Lit le fichier généré, remplace :root par .theme-{nom} et [data-themeable] par .theme-{nom} [data-themeable],
+ * Lit le fichier généré, remplace :root par .theme-{nom} et [data-themeable="true"] par .theme-{nom} [data-themeable="true"],
  * puis l'ajoute au fichier contenant l'ensemble des thèmes
  */
 StyleDictionary.registerAction({
@@ -126,11 +126,11 @@ StyleDictionary.registerAction({
     const fichierTheme = join(config.buildPath ?? "", `lab-anssi-theme.${nomTheme}.css`);
     const contenu = readFileSync(fichierTheme, "utf-8") + "\n";
 
-    // Remplacer :root par .theme-{nom}, [data-themeable] par .theme-{nom} [data-themeable], et retirer le header
+    // Remplacer :root par .theme-{nom}, [data-themeable="true"] par .theme-{nom} [data-themeable="true"], et retirer le header
     const contenuTheme = contenu
       .replace(/\/\*\*[\s\S]*?\*\/\s*/, "") // Retirer le header
       .replace(":root {", `.theme-${nomTheme} {`)
-      .replace("[data-themeable] {", `.theme-${nomTheme} [data-themeable] {`);
+      .replace(`[data-themeable="true"] {`, `.theme-${nomTheme} [data-themeable="true"] {`);
 
     appendFileSync(FICHIER_TOUS_THEMES, contenuTheme);
   },


### PR DESCRIPTION
## Décrire les changements

Cette PR effectue plusieurs évolutions concernant l'application des thèmes afin d'améliorer leur activation/désactivation sur les composants.

Ainsi la PR ajoute les implémentations suivantes : 
- Spécifie l'usage de la prop `data-themeable` : l'application des thèmes s'effectuent doréanavant avec l'application du sélecteur `data-themeable="true"` et plus uniquement `data-themeable`. Cette évolution est faite pour rendre le CSS ISO avec l'application de cet attribut fait par la fonction `setThemeable` et ouvre également ainsi la possibilité de désactiver l'application des thèmes en mettant une valeur `false` sur l'attribut `data-themeable`.
- L'évolution de la fonction `setThemeable` afin de lui passer un nouveau paramètre `active` permettant spécifier directement dans les composants Svelte, si la valeur de l'attribut `data-themeable` doit être à `true` ou `false`. En d'autres termes, si le composant doit être thématisable ou non par défaut.
- Le fait de rendre de façon explicite les composants `DsfrHeader` et `DsfrFooter` comme non thématisable.
- L'évolution de la feuille de styles `dsfr-variables` afin d'appliquer les variables par défaut du DSFR au sélecteur `[data-themeable="false"]`
- La mise à jour de la documentation en regard de toutes ces dernières évolutions 

## Autres informations

<!-- Ajoutez ici tout autre commentaire ou toute autre information concernant cette Pull Request. -->
