### PR TITLE
[COMPOSANT] LAB - LienDiagnosticCyber : Ajoute la prop `label`

### DIFF
--- a/src/lib/composants/mes-services-cyber/lien/LienDiagnosticCyber.svelte
+++ b/src/lib/composants/mes-services-cyber/lien/LienDiagnosticCyber.svelte
@@ -1,22 +1,32 @@
-<svelte:options customElement="lab-anssi-mes-services-cyber-lien-diagnostic-cyber" />
+<svelte:options
+  customElement={{
+    tag: "lab-anssi-mes-services-cyber-lien-diagnostic-cyber",
+    props: {
+      label: { attribute: "label", type: "String" },
+      lien: { attribute: "lien", type: "String" },
+      versExterne: { attribute: "vers-externe", type: "Boolean" },
+    },
+  }}
+/>
 
 <script lang="ts">
   import { srcAsset } from "$lib/assets/assets";
 
   interface Props {
-    lien: any;
+    label: string;
+    lien?: any;
     versExterne?: boolean;
   }
 
-  let { lien, versExterne = false }: Props = $props();
-  let target = versExterne ? "_blank" : "_self";
-  let rel = versExterne ? "noreferrer" : undefined;
-  let icone = versExterne ? "lien-externe" : "lien-interne";
+  let { label = "Votre diagnostic cyber gratuit", lien, versExterne = false }: Props = $props();
+  let target = $derived(versExterne ? "_blank" : "_self");
+  let rel = $derived(versExterne ? "noreferrer" : undefined);
+  let icone = $derived(versExterne ? "lien-externe" : "lien-interne");
 </script>
 
 <div class="racine">
   <a href={lien} {target} class="lien-diagnostic-cyber" {rel}>
-    Votre diagnostic cyber gratuit
+    {label}
     <img
       src={srcAsset(`/icones/${icone}.svg`)}
       alt={`lien-${versExterne ? "externe" : "interne"}`}

--- a/stories/composants/LienDiagnosticCyber.stories.svelte
+++ b/stories/composants/LienDiagnosticCyber.stories.svelte
@@ -9,6 +9,7 @@
     title: "Composants/ANSSI/Lien Diagnostic Cyber",
     component: LienDiagnosticCyber,
     args: {
+      label: "Votre diagnostic cyber gratuit",
       lien: "#",
       versExterne: false,
     },
@@ -21,6 +22,7 @@
 {#snippet template(args: Args)}
   <ConteneurStory alignement="droite">
     <lab-anssi-mes-services-cyber-lien-diagnostic-cyber
+      label={args.label}
       lien={args.lien}
       vers-externe={args.versExterne || undefined}
     ></lab-anssi-mes-services-cyber-lien-diagnostic-cyber>


### PR DESCRIPTION
## Décrire les changements

Le composant "Lien diagnostic cyber" avait la valeur du label du bouton en dur.
Cette PR ajoute une prop `label` qui permet de personnaliser la valeur du bouton lorsque cela est nécessaire.

La PR ajoute également la définition de l'ensemble des props dans la balise `svelte:options`.