### PR TITLE
[COMPOSANT] DsfrTable - Nettoyage du code et suppression de fonctionnalités inutilisées

### DIFF
--- a/src/lib/dsfr/DsfrTable.svelte
+++ b/src/lib/dsfr/DsfrTable.svelte
@@ -163,21 +163,21 @@
     /**
      * Nombre total de lignes (mode pagination serveur).
      * Si fourni, désactive le slicing interne : le composant affiche les `rows` telles quelles
-     * et délègue la gestion des données au parent via `onpagechange` / `onrowsperpagechange`.
+     * et délègue la gestion des données au parent via `onpagechanged` / `onrowsperpagechanged`.
      */
     totalRows?: number;
     /**
      * Callback appelé lors d'un changement de page.
-     * En mode web component, un `CustomEvent<number>` `pagechange` est également dispatché
-     * sur l'élément (utilisable via `<dsfr-table onpagechange={(e) => …}>`).
+     * En mode web component, un `CustomEvent<number>` `pagechanged` est également dispatché
+     * sur l'élément (utilisable via `<dsfr-table onpagechanged={(e) => …}>`).
      */
-    onpagechange?: (page: number) => void;
+    onpagechanged?: (page: number) => void;
     /**
      * Callback appelé lors d'un changement du nombre de lignes par page.
-     * En mode web component, un `CustomEvent<number>` `rowsperpagechange` est également dispatché
-     * sur l'élément (utilisable via `<dsfr-table onrowsperpagechange={(e) => …}>`).
+     * En mode web component, un `CustomEvent<number>` `rowsperpagechanged` est également dispatché
+     * sur l'élément (utilisable via `<dsfr-table onrowsperpagechanged={(e) => …}>`).
      */
-    onrowsperpagechange?: (rowsPerPage: number) => void;
+    onrowsperpagechanged?: (rowsPerPage: number) => void;
     /**
      * Active les slots nommés `cell:<colKey>:<rowIndex>` sur **toutes** les cellules du tableau,
      * permettant d'injecter du contenu personnalisé via le light DOM
@@ -220,8 +220,8 @@
     rows,
     itemsPerPage = [5, 10, 20],
     totalRows,
-    onpagechange,
-    onrowsperpagechange,
+    onpagechanged,
+    onrowsperpagechanged,
     rich = false,
   }: Props = $props();
 
@@ -290,14 +290,14 @@
     const newValue = parseInt(value, 10);
     rowsPerPage = newValue;
     currentPage = 1;
-    onrowsperpagechange?.(newValue);
-    $host()?.dispatchEvent(new CustomEvent("rowsperpagechange", { detail: newValue }));
+    onrowsperpagechanged?.(newValue);
+    $host()?.dispatchEvent(new CustomEvent("rowsperpagechanged", { detail: newValue }));
   }
 
   function handlePageChange(page: number) {
     currentPage = page;
-    onpagechange?.(page);
-    $host()?.dispatchEvent(new CustomEvent("pagechange", { detail: page }));
+    onpagechanged?.(page);
+    $host()?.dispatchEvent(new CustomEvent("pagechanged", { detail: page }));
   }
 
   /**

--- a/src/lib/dsfr/DsfrTable.svelte
+++ b/src/lib/dsfr/DsfrTable.svelte
@@ -166,9 +166,17 @@
      * et délègue la gestion des données au parent via `onpagechange` / `onrowsperpagechange`.
      */
     totalRows?: number;
-    /** Callback appelé lors d'un changement de page */
+    /**
+     * Callback appelé lors d'un changement de page.
+     * En mode web component, un `CustomEvent<number>` `pagechange` est également dispatché
+     * sur l'élément (utilisable via `<dsfr-table onpagechange={(e) => …}>`).
+     */
     onpagechange?: (page: number) => void;
-    /** Callback appelé lors d'un changement du nombre de lignes par page */
+    /**
+     * Callback appelé lors d'un changement du nombre de lignes par page.
+     * En mode web component, un `CustomEvent<number>` `rowsperpagechange` est également dispatché
+     * sur l'élément (utilisable via `<dsfr-table onrowsperpagechange={(e) => …}>`).
+     */
     onrowsperpagechange?: (rowsPerPage: number) => void;
     /**
      * Active les slots nommés `cell:<colKey>:<rowIndex>` sur **toutes** les cellules du tableau,
@@ -283,11 +291,13 @@
     rowsPerPage = newValue;
     currentPage = 1;
     onrowsperpagechange?.(newValue);
+    $host()?.dispatchEvent(new CustomEvent("rowsperpagechange", { detail: newValue }));
   }
 
   function handlePageChange(page: number) {
     currentPage = page;
     onpagechange?.(page);
+    $host()?.dispatchEvent(new CustomEvent("pagechange", { detail: page }));
   }
 
   /**

--- a/src/lib/dsfr/DsfrTable.svelte
+++ b/src/lib/dsfr/DsfrTable.svelte
@@ -34,7 +34,6 @@
 />
 
 <script lang="ts">
-  import type { Snippet } from "svelte";
   import type { Size } from "$lib/types";
   import { setThemeable } from "$lib/utilitaires";
 
@@ -100,12 +99,6 @@
     sort?: boolean;
     inline?: boolean;
     multiline?: boolean;
-    /**
-     * Snippet de rendu personnalisé pour les cellules de cette colonne (Svelte uniquement).
-     * Reçoit la valeur brute de la cellule et la ligne d'origine complète.
-     * Non sérialisable en JSON : incompatible avec le passage via attribut HTML.
-     */
-    render?: Snippet<[value: unknown, row: Row]>;
   }
 
   export interface Props {
@@ -174,8 +167,8 @@
      * permettant d'injecter du contenu personnalisé via le light DOM
      * (ex: `<div slot="cell:maColonne:0">…</div>`).
      *
-     * Utile principalement en contexte web component, où `Column.render` (Svelte uniquement)
-     * n'est pas disponible. Le rendu standard sert de fallback si aucun slot n'est fourni.
+     * Utile principalement en contexte web component.
+     * Le rendu standard sert de fallback si aucun slot n'est fourni.
      *
      * ⚠️ Coût non-négligeable sur les gros tableaux : un `<slot>` est créé par cellule.
      * À n'activer que si la fonctionnalité est utilisée.
@@ -258,14 +251,6 @@
   let currentPage = $state(1);
 
   let totalPages = $derived(Math.ceil(nbRows / rowsPerPage));
-
-  // Lignes d'origine (Row[]) alignées sur displayedRows, pour les render snippets par colonne.
-  let displayedOriginalRows = $derived.by((): Row[] => {
-    if (!rows) return [];
-    if (isServerSide) return rows;
-    if (!hasFooterSelect && !hasFooterPagination) return rows;
-    return rows.slice((currentPage - 1) * rowsPerPage, currentPage * rowsPerPage);
-  });
 
   let displayedRows = $derived.by(() => {
     const allRows = computedTbodies[0] ?? [];
@@ -448,14 +433,7 @@
                           class={getCellClasses(cell)}
                           use:cellSlot={rich && col ? `cell:${col.key}:${globalIndex}` : null}
                         >
-                          {#if col?.render && tIndex === 0}
-                            {@render col.render(
-                              displayedOriginalRows[index][col.key],
-                              displayedOriginalRows[index],
-                            )}
-                          {:else}
-                            {cell.content}
-                          {/if}
+                          {cell.content}
                         </td>
                       {/each}
                     </tr>

--- a/src/lib/dsfr/DsfrTable.svelte
+++ b/src/lib/dsfr/DsfrTable.svelte
@@ -99,6 +99,14 @@
     sort?: boolean;
     inline?: boolean;
     multiline?: boolean;
+    /**
+     * Active le slot nommé `cell:<key>:<rowIndex>` uniquement sur les cellules de cette colonne.
+     * Permet une activation granulaire de la personnalisation par light DOM, sans payer le coût
+     * d'un `<slot>` par cellule sur les colonnes qui n'en ont pas besoin.
+     *
+     * Cumulatif avec la prop globale `rich` : si l'une des deux est `true`, le slot est activé.
+     */
+    rich?: boolean;
   }
 
   export interface Props {
@@ -163,7 +171,7 @@
     /** Callback appelé lors d'un changement du nombre de lignes par page */
     onrowsperpagechange?: (rowsPerPage: number) => void;
     /**
-     * Active les slots nommés `cell:<colKey>:<rowIndex>` sur chaque cellule du tableau,
+     * Active les slots nommés `cell:<colKey>:<rowIndex>` sur **toutes** les cellules du tableau,
      * permettant d'injecter du contenu personnalisé via le light DOM
      * (ex: `<div slot="cell:maColonne:0">…</div>`).
      *
@@ -171,7 +179,8 @@
      * Le rendu standard sert de fallback si aucun slot n'est fourni.
      *
      * ⚠️ Coût non-négligeable sur les gros tableaux : un `<slot>` est créé par cellule.
-     * À n'activer que si la fonctionnalité est utilisée.
+     * Pour une activation ciblée par colonne (sans payer le coût sur les autres),
+     * utiliser plutôt `Column.rich` au cas par cas.
      */
     rich?: boolean;
   }
@@ -431,7 +440,9 @@
                         {@const col = columns?.[cellIndex]}
                         <td
                           class={getCellClasses(cell)}
-                          use:cellSlot={rich && col ? `cell:${col.key}:${globalIndex}` : null}
+                          use:cellSlot={col && (rich || col.rich)
+                            ? `cell:${col.key}:${globalIndex}`
+                            : null}
                         >
                           {cell.content}
                         </td>

--- a/src/lib/dsfr/DsfrTable.svelte
+++ b/src/lib/dsfr/DsfrTable.svelte
@@ -110,10 +110,10 @@
   }
 
   export interface Props {
-    /** Id du tableau */
-    id?: string;
     /** Titre du tableau */
     caption: string;
+    /** Id du tableau */
+    id?: string;
     /** Description précise du tableau */
     captionDetail?: string;
     /** Cache le texte de la caption (reste présent pour l'accessibilité) */
@@ -192,6 +192,37 @@
      */
     rich?: boolean;
   }
+
+  let wrapperEl: HTMLDivElement | undefined = $state();
+  let captionEl: HTMLTableCaptionElement | undefined = $state();
+
+  /**
+   * Observateur de redimensionnement qui met à jour le décalage du tableau en fonction de la hauteur de la légende.
+   * Calcule la hauteur de la légende et définit la variable CSS `--table-offset` pour ajuster l'espacement du wrapper.
+   * Le callback `update` est appelé chaque fois que la légende change de taille.
+   */
+  $effect(() => {
+    if (noCaption || !wrapperEl || !captionEl) {
+      wrapperEl?.style.removeProperty("--table-offset");
+
+      return;
+    }
+
+    const update = () => {
+      wrapperEl!.style.removeProperty("--table-offset");
+
+      const height = captionEl!.getBoundingClientRect().height;
+
+      wrapperEl!.style.setProperty("--table-offset", `calc(${height}px + 1rem)`);
+    };
+
+    update();
+
+    const observer = new ResizeObserver(update);
+    observer.observe(captionEl);
+
+    return () => observer.disconnect();
+  });
 
   let {
     id,
@@ -395,12 +426,12 @@
     </div>
   {/if}
 
-  <div class="fr-table__wrapper">
+  <div bind:this={wrapperEl} class="fr-table__wrapper">
     <div class="fr-table__container">
       <div class="fr-table__content">
         <slot name="tablecontent">
           <table {id}>
-            <caption>
+            <caption bind:this={captionEl}>
               {caption}
               {#if captionDetail}
                 <div class="fr-table__caption__desc">{captionDetail}</div>

--- a/src/lib/dsfr/DsfrTable.svelte
+++ b/src/lib/dsfr/DsfrTable.svelte
@@ -88,6 +88,8 @@
     tbodies: TbodyCell[][][];
   }
 
+  type Row = Record<string, unknown>;
+
   interface Column {
     key: string;
     label: string;
@@ -99,20 +101,12 @@
     inline?: boolean;
     multiline?: boolean;
     /**
-     * Si true, le contenu de chaque cellule est rendu comme du HTML brut via {@html}.
-     * Fonctionne avec l'API columns/rows, y compris en tant que web component.
-     * ⚠️ Ne pas utiliser avec des données non maîtrisées (risque XSS).
-     */
-    html?: boolean;
-    /**
      * Snippet de rendu personnalisé pour les cellules de cette colonne (Svelte uniquement).
      * Reçoit la valeur brute de la cellule et la ligne d'origine complète.
      * Non sérialisable en JSON : incompatible avec le passage via attribut HTML.
      */
     render?: Snippet<[value: unknown, row: Row]>;
   }
-
-  type Row = Record<string, unknown>;
 
   export interface Props {
     /** Id du tableau */
@@ -176,9 +170,15 @@
     /** Callback appelé lors d'un changement du nombre de lignes par page */
     onrowsperpagechange?: (rowsPerPage: number) => void;
     /**
-     * Bascule le rendu interne en divs avec rôles ARIA.
-     * Permet aux consommateurs d'injecter du contenu riche dans les cellules via des slots nommés
-     * (ex: slot="cell:maColonne:0"), sans contrainte sur le format table HTML.
+     * Active les slots nommés `cell:<colKey>:<rowIndex>` sur chaque cellule du tableau,
+     * permettant d'injecter du contenu personnalisé via le light DOM
+     * (ex: `<div slot="cell:maColonne:0">…</div>`).
+     *
+     * Utile principalement en contexte web component, où `Column.render` (Svelte uniquement)
+     * n'est pas disponible. Le rendu standard sert de fallback si aucun slot n'est fourni.
+     *
+     * ⚠️ Coût non-négligeable sur les gros tableaux : un `<slot>` est créé par cellule.
+     * À n'activer que si la fonctionnalité est utilisée.
      */
     rich?: boolean;
   }
@@ -215,27 +215,6 @@
     rich = false,
   }: Props = $props();
 
-  let captionEl: HTMLElement | undefined = $state();
-  let tableOffset = $state("0px");
-
-  $effect(() => {
-    if (!captionEl || noCaption) {
-      tableOffset = "0px";
-      return;
-    }
-
-    const updateOffset = () => {
-      const captionHeight = captionEl.getBoundingClientRect().captionHeight;
-      tableOffset = `calc(${captionHeight}px + 1rem)`;
-    };
-
-    const observer = new ResizeObserver(updateOffset);
-    observer.observe(captionEl);
-    updateOffset();
-
-    return () => observer.disconnect();
-  });
-
   let computedThead = $derived(
     columns
       ? [
@@ -270,17 +249,12 @@
       : (table?.tbodies ?? []),
   );
 
-  // En mode serveur _(présence de `totalRows`)_, le parent gère le découpage : on affiche toutes les rows reçues.
+  // En mode serveur (présence de `totalRows`), le parent gère le découpage : on affiche toutes les rows reçues.
   // En mode client, le composant calcule lui-même le nombre total depuis les données.
   let isServerSide = $derived(totalRows !== undefined);
   let nbRows = $derived(isServerSide ? (totalRows ?? 0) : (computedTbodies[0]?.length ?? 0));
 
   let rowsPerPage = $state(itemsPerPage[0]);
-
-  $effect(() => {
-    rowsPerPage = itemsPerPage[0];
-  });
-
   let currentPage = $state(1);
 
   let totalPages = $derived(Math.ceil(nbRows / rowsPerPage));
@@ -323,14 +297,6 @@
   }
 
   /**
-   * Génère les classes CSS applicables à une cellule de tableau en fonction de ses propriétés.
-   *
-   * @param {TheadCell | TbodyCell} cell - La cellule dont les classes doivent être générées
-   * @param {boolean} [isHeader=false] - Indique si la cellule est un en-tête de colonne
-   * @param {boolean} [forceFixed=false] - Force l'application de la classe de cellule fixe
-   * @returns {string[]} Un tableau contenant les classes CSS à appliquer à la cellule
-   */
-  /**
    * Action Svelte : crée un `<slot name="...">` programmatiquement dans le `<td>`,
    * en déplaçant le contenu Svelte existant comme fallback du slot.
    * Contourne la restriction compile-time de Svelte sur les noms de slot dynamiques.
@@ -360,6 +326,14 @@
     };
   }
 
+  /**
+   * Génère les classes CSS applicables à une cellule de tableau en fonction de ses propriétés.
+   *
+   * @param cell La cellule dont les classes doivent être générées
+   * @param isHeader Indique si la cellule est un en-tête de colonne
+   * @param forceFixed Force l'application de la classe de cellule fixe
+   * @returns Les classes CSS à appliquer à la cellule
+   */
   function getCellClasses(
     cell: TheadCell | TbodyCell,
     isHeader = false,
@@ -417,7 +391,7 @@
     </div>
   {/if}
 
-  <div class="fr-table__wrapper" style={`--table-offset: ${tableOffset};`}>
+  <div class="fr-table__wrapper">
     <div class="fr-table__container">
       <div class="fr-table__content">
         <slot name="tablecontent">
@@ -429,7 +403,7 @@
               {/if}
             </caption>
 
-            {#if computedThead?.length}
+            {#if computedThead.length}
               <thead>
                 {#each computedThead as row, rowIndex (rowIndex)}
                   <tr>
@@ -464,7 +438,10 @@
                   {#each tIndex === 0 ? displayedRows : tbody as row, index (index)}
                     {@const globalIndex =
                       tIndex === 0 ? (currentPage - 1) * rowsPerPage + index : index}
-                    <tr id={`${id}-row-key-${globalIndex}`} data-row-key={globalIndex}>
+                    <tr
+                      id={id ? `${id}-row-key-${globalIndex}` : undefined}
+                      data-row-key={globalIndex}
+                    >
                       {#each row as cell, cellIndex (cellIndex)}
                         {@const col = columns?.[cellIndex]}
                         <td
@@ -476,8 +453,6 @@
                               displayedOriginalRows[index][col.key],
                               displayedOriginalRows[index],
                             )}
-                          {:else if col?.html}
-                            {@html cell.content}
                           {:else}
                             {cell.content}
                           {/if}

--- a/stories/dsfr/Table.stories.svelte
+++ b/stories/dsfr/Table.stories.svelte
@@ -122,10 +122,6 @@
   type Args = ComponentProps<DsfrTable>;
 </script>
 
-{#snippet contenuCellulePopulation(value: unknown, _row: Record<string, unknown>)}
-  <strong>{value as string} hab.</strong>
-{/snippet}
-
 {#snippet template(args: Args)}
   <dsfr-table
     id={args.id}
@@ -201,23 +197,6 @@
         serverPerPage = perPage;
         serverPage = 1;
       }}
-    />
-  {/snippet}
-</Story>
-
-<Story name="Avec contenu riche (snippet)">
-  {#snippet template(_args: Args)}
-    <DsfrTable
-      id="table-rich-snippet"
-      caption="Grandes villes de France"
-      columns={[
-        { key: "0", label: "Ville" },
-        { key: "1", label: "Département" },
-        { key: "2", label: "Région" },
-        { key: "3", label: "Population (2020)", render: contenuCellulePopulation },
-        { key: "4", label: "Superficie (km²)" },
-      ]}
-      rows={citiesRows.slice(0, 10)}
     />
   {/snippet}
 </Story>

--- a/stories/dsfr/Table.stories.svelte
+++ b/stories/dsfr/Table.stories.svelte
@@ -190,10 +190,10 @@
       hasFooterSelect
       hasFooterPagination
       itemsPerPage={[5, 10, 20]}
-      onpagechange={(page) => {
+      onpagechanged={(page) => {
         serverPage = page;
       }}
-      onrowsperpagechange={(perPage) => {
+      onrowsperpagechanged={(perPage) => {
         serverPerPage = perPage;
         serverPage = 1;
       }}

--- a/stories/dsfr/TableRich.stories.svelte
+++ b/stories/dsfr/TableRich.stories.svelte
@@ -157,11 +157,10 @@
       id="table-nis2"
       caption="Liste des exigences NIS 2"
       multiline
-      rich
       columns={[
-        { key: "exigence", label: "Exigence NIS 2", multiline: true },
-        { key: "correspondance", label: "Correspondance" },
-        { key: "isoRefs", label: "Référence ISO 27001/27002", multiline: true },
+        { key: "exigence", label: "Exigence NIS 2", multiline: true, rich: true },
+        { key: "correspondance", label: "Correspondance", rich: true },
+        { key: "isoRefs", label: "Référence ISO 27001/27002", multiline: true, rich: true },
         { key: "observation", label: "Observations", multiline: true },
       ]}
       rows={nisRows}

--- a/stories/dsfr/TableRich.stories.svelte
+++ b/stories/dsfr/TableRich.stories.svelte
@@ -1,16 +1,9 @@
 <script module lang="ts">
   import { defineMeta } from "@storybook/addon-svelte-csf";
-  import { type ComponentProps } from "svelte";
-
-  import {
-    tableArgTypes,
-    tableArgs,
-  } from "@gouvfr/dsfr/src/dsfr/component/table/template/stories/table-arg-types.js";
 
   import DsfrBadge from "$lib/dsfr/DsfrBadge.svelte";
   import DsfrTag from "$lib/dsfr/DsfrTag.svelte";
   import DsfrTable from "$lib/dsfr/DsfrTable.svelte";
-  import DsfrButtonsGroup from "$lib/dsfr/DsfrButtonsGroup.svelte";
   import webComponentSourceCode from "../utilitaires/webComponentSource.js";
 
   type Nis2Correspondance = "ÉLEVÉE" | "MOYENNE" | "FAIBLE / NULLE";
@@ -148,37 +141,6 @@
   const { Story } = defineMeta({
     title: "Composants/dsfr/Table",
     component: DsfrTable,
-    argTypes: {
-      ...tableArgTypes,
-      layoutFixed: {
-        control: "boolean",
-        description: "Fixe la mise en page du tableau (table-layout: fixed)",
-      },
-      fixedFirstCellHead: {
-        control: "boolean",
-        description: "Fixe la première cellule de l'en-tête (sticky)",
-      },
-    },
-    args: {
-      ...tableArgs,
-      buttons: [
-        {
-          label: "Action tableau",
-          kind: "primary",
-          disabled: false,
-          icon: "checkbox-circle-line",
-        },
-        {
-          label: "Action tableau",
-          kind: "secondary",
-          disabled: false,
-          icon: "checkbox-circle-line",
-        },
-      ],
-      itemsPerPage: [5, 10, 20],
-      layoutFixed: false,
-      fixedFirstCellHead: false,
-    },
     parameters: {
       docs: {
         source: {
@@ -186,46 +148,11 @@
         },
       },
     },
-    render: template,
   });
-
-  type Args = ComponentProps<DsfrTable>;
 </script>
 
-{#snippet template(args: Args)}
-  <dsfr-table
-    id={args.id}
-    caption={args.caption}
-    caption-detail={args.captionDetail}
-    no-caption={args.noCaption || undefined}
-    caption-bottom={args.captionBottom || undefined}
-    bordered={args.bordered || undefined}
-    no-scroll={args.noScroll || undefined}
-    multiline={args.multiline || undefined}
-    layout-fixed={args.layoutFixed || undefined}
-    size={args.size}
-    fixed-first-cell-head={args.fixedFirstCellHead || undefined}
-    has-header={args.hasHeader || undefined}
-    has-header-segmented={args.hasHeaderSegmented || undefined}
-    has-header-search={args.hasHeaderSearch || undefined}
-    has-header-details={args.hasHeaderDetails || undefined}
-    header-details={args.headerDetails}
-    has-header-buttons={args.hasHeaderButtons || undefined}
-    has-footer={args.hasFooter || undefined}
-    has-footer-select={args.hasFooterSelect || undefined}
-    has-footer-pagination={args.hasFooterPagination || undefined}
-    has-footer-buttons={args.hasFooterButtons || undefined}
-    columns={args.columns}
-    rows={args.rows}
-    items-per-page={JSON.stringify(args.itemsPerPage)}
-  >
-    <dsfr-buttons-group slot="footerbuttons" buttons={args.buttons} inline="true"
-    ></dsfr-buttons-group>
-  </dsfr-table>
-{/snippet}
-
 <Story name="Avec contenu riche (Maquette NIS2)">
-  {#snippet template(_args: Args)}
+  {#snippet template()}
     <dsfr-table
       id="table-nis2"
       caption="Liste des exigences NIS 2"


### PR DESCRIPTION
## Décrire les changements

Cette PR effectue plusieurs évolutions sur le composant `DsfrTable` et les stories associées visant non seulement à nettoyer le code mort, incohérent ou inutilisé mais à rendre le composant et son API plus "légère", plus compréhensible et plus cohérente avec une utilisation en WebComponent.

Ainsi cette PR implémente les évolutions suivantes :
- Nettoyage ou suppression de commentaires/fonctionnalités incohérentes ou inutilisées _(ex: `Column.html`, `tableOffset`, etc...)_
- Retrait de l'usage "`render`" propre aux composants Svelte mais non nécessaire dans le cadre des WebComponents
- Ajout de la propriété `rich` au niveau des éléments "column", dans le but d'améliorer les performances du composant et de ne pas "sloter" toutes les cellules systématiquement.
- Ajout de `CustomEvent` pour garantir la bonne utilisation des évènements en mode WebComponent
- Corrige l'affichage du caption

## Autres informations

<!-- Ajoutez ici tout autre commentaire ou toute autre information concernant cette Pull Request. -->
