### PR TITLE
[COMPOSANT] DsfrSearch - Ajoute le type de bouton et améliore la gestion des événements de soumission

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@lab-anssi/ui-kit",
-  "version": "1.50.0",
+  "version": "1.50.1",
   "repository": {
     "type": "git",
     "url": "git+https://github.com/betagouv/lab-anssi-ui-kit.git"

--- a/src/lib/dsfr/DsfrSearch.svelte
+++ b/src/lib/dsfr/DsfrSearch.svelte
@@ -6,6 +6,7 @@
       inputLabel: { attribute: "input-label", type: "String" },
       buttonLabel: { attribute: "button-label", type: "String" },
       buttonTitle: { attribute: "button-title", type: "String" },
+      buttonType: { attribute: "button-type", type: "String" },
       size: { attribute: "size", type: "String" },
       placeholder: { attribute: "placeholder", type: "String" },
       value: { attribute: "value", type: "String", reflect: true },
@@ -49,6 +50,8 @@
     buttonLabel: string;
     /** Titre du bouton */
     buttonTitle: string;
+    /** Type du bouton */
+    buttonType: "button" | "submit";
     /** Taille de la barre de recherche (défaut: md) */
     size?: SearchSize;
     /** Placeholder de l'input */
@@ -82,6 +85,7 @@
     inputLabel,
     buttonLabel,
     buttonTitle,
+    buttonType = "submit",
     size = "md",
     placeholder,
     value = $bindable(),
@@ -102,10 +106,48 @@
   const formValidation = createFormValidation();
   const sizeClass = $derived(`fr-search-bar--${size}`);
 
+  /**
+   * Gère le changement de valeur de l'input de recherche.
+   * Met à jour la valeur et déclenche l'événement 'valuechanged'.
+   *
+   * @param {Event} event - L'événement input
+   */
   function handleInput(event: Event) {
     const target = event.target as HTMLInputElement;
+
     value = target.value;
+
     dispatch("valuechanged", target.value);
+  }
+
+  /**
+   * Gère le clic sur le bouton de recherche.
+   * Si le bouton est de type "submit" et associé à un formulaire, on soumet le formulaire.
+   * Sinon, déclenche l'événement de recherche personnalisé.
+   *
+   * @param {MouseEvent | KeyboardEvent} event - L'événement souris ou clavier
+   */
+  function handleButtonClick(event: MouseEvent | KeyboardEvent) {
+    if (buttonType === "submit" && internals?.form) {
+      event.preventDefault();
+      internals.form.requestSubmit();
+
+      return;
+    }
+
+    dispatch("search", value);
+  }
+
+  /**
+   * Déclenche la recherche si la touche Entrée est pressée.
+   * Le comportement par défaut de la touche Entrée dans un champ de recherche est de soumettre le formulaire. Cependant, si le bouton de recherche n'est pas de type "submit", nous voulons déclencher l'événement de recherche personnalisé.
+   *
+   * @param {KeyboardEvent} event - L'événement clavier
+   */
+  function handleInputKeydown(event: KeyboardEvent) {
+    if (event.key !== "Enter") return;
+
+    handleButtonClick(event);
   }
 
   export function setCustomValidity(message: string) {
@@ -139,6 +181,7 @@
     bind:value
     {placeholder}
     oninput={handleInput}
+    onkeydown={handleInputKeydown}
     onblur={formValidation.handleBlur}
     oninvalid={formValidation.handleInvalid}
     {disabled}
@@ -151,7 +194,13 @@
     {required}
   />
 
-  <button title={buttonTitle} type="button" class="fr-btn" {disabled}>
+  <button
+    title={buttonTitle}
+    type={buttonType}
+    class="fr-btn"
+    {disabled}
+    onclick={handleButtonClick}
+  >
     {buttonLabel}
   </button>
 </div>


### PR DESCRIPTION
## Décrire les changements

Le composant `DsfrSearch` tel qu'[il a été développé](https://github.com/betagouv/lab-anssi-ui-kit/commit/bce7c65a614137fb8c644c384d12f371fa7bc86a) initialement ne permettait pas d'obtenir d'informations lors du clic sur le bouton de soumission présent dans le composant, rendant ainsi le composant quasiment inutilisable en l'état.
Le seul évènement émit jusqu'alors était `valuechanged`, émit à chaque changement de valeur de l'input.

Cette PR vient améliorer le fonctionnement de ce composant afin de le rendre pleinement opérationnel.

Ainsi la PR implémente les évolutions suivantes : 
- Ajout de la prop `buttonType` qui permet de choisir le type de bouton entre les valeurs `button` ou `submit` _(`submit` étant la valeur par défaut)_
- L'émission d'un évènement `search` au clic sur le bouton dès lors qu'il est de type `button`
- La soumission du formulaire au clic sur le bouton dès lors que ce dernier est de type `submit`
- La mise en oeuvre du fonctionnement des deux points précédents lors de l'appui sur la touche "Entrée" à l'intérieur du champ `input`

## Autres informations

<!-- Ajoutez ici tout autre commentaire ou toute autre information concernant cette Pull Request. -->
