### PR TITLE
[COMPOSANT] DsfrTable - Ajoute la variation 'selectable'

### DIFF
--- a/src/lib/dsfr/DsfrTable.svelte
+++ b/src/lib/dsfr/DsfrTable.svelte
@@ -30,6 +30,7 @@
       totalRows: { attribute: "total-rows", type: "Number" },
       rich: { attribute: "rich", type: "Boolean" },
       selectable: { attribute: "selectable", type: "Boolean" },
+      selectAll: { attribute: "select-all", type: "Boolean" },
       rowKey: { attribute: "row-key", type: "String" },
       selectedRowKeys: { attribute: "selected-row-keys", type: "Array" },
     },
@@ -39,6 +40,7 @@
 <script lang="ts">
   import type { Size } from "$lib/types";
   import { setThemeable } from "$lib/utilitaires";
+  import { setIndeterminate } from "$lib/directives/actions.svelte.ts";
 
   import DsfrPagination from "$lib/dsfr/DsfrPagination.svelte";
   import DsfrSelect from "$lib/dsfr/DsfrSelect.svelte";
@@ -199,6 +201,13 @@
      */
     selectable?: boolean;
     /**
+     * Affiche une case à cocher « tout sélectionner » dans l'en-tête du tableau.
+     * Permet de sélectionner/désélectionner toutes les lignes de la page courante.
+     * L'état indéterminé s'active automatiquement quand une partie des lignes est sélectionnée.
+     * Nécessite `selectable` pour être actif.
+     */
+    selectAll?: boolean;
+    /**
      * Nom de la clé dans les objets `Row` à utiliser comme identifiant unique pour la sélection.
      * Si absent, l'index de la ligne est utilisé.
      */
@@ -274,6 +283,7 @@
     onrowsperpagechanged,
     rich = false,
     selectable = false,
+    selectAll = false,
     rowKey,
     selectedRowKeys,
     onselectionchanged,
@@ -399,6 +409,24 @@
   );
   let selectedKeysSet = $derived(new Set<string | number>(activeSelectedKeys));
 
+  let displayedRowKeys = $derived.by(() => {
+    if (!selectable || !selectAll) return [];
+
+    return displayedRows.map((_, index) => {
+      const rowIndex = (currentPage - 1) * rowsPerPage + index;
+      const originalRow = rows?.[isServerSide ? index : rowIndex] ?? {};
+
+      return getRowKey(originalRow, rowIndex);
+    });
+  });
+
+  let allRowsSelected = $derived(
+    displayedRowKeys.length > 0 && displayedRowKeys.every((key) => selectedKeysSet.has(key)),
+  );
+  let someRowsSelected = $derived(
+    displayedRowKeys.some((key) => selectedKeysSet.has(key)) && !allRowsSelected,
+  );
+
   /**
    * Vérifie si une ligne est actuellement sélectionnée.
    *
@@ -428,6 +456,31 @@
 
     if (checked) updatedSelection.add(key);
     else updatedSelection.delete(key);
+
+    const updatedKeys = Array.from(updatedSelection);
+    const updatedRows = (rows ?? []).filter((r, i) => updatedSelection.has(getRowKey(r, i)));
+
+    if (!isSelectionControlled) internalSelectedKeys = updatedKeys;
+
+    onselectionchanged?.(updatedKeys, updatedRows);
+    $host()?.dispatchEvent(
+      new CustomEvent("selectionchanged", { detail: { keys: updatedKeys, rows: updatedRows } }),
+    );
+  }
+
+  /**
+   * Sélectionne ou désélectionne toutes les lignes actuellement affichées,
+   * puis émet l'événement de changement de sélection.
+   *
+   * @param checked - Indique si toutes les lignes visibles doivent être sélectionnées (`true`) ou désélectionnées (`false`).
+   */
+  function handleSelectAll(checked: boolean) {
+    const updatedSelection = new Set(activeSelectedKeys);
+
+    for (const key of displayedRowKeys) {
+      if (checked) updatedSelection.add(key);
+      else updatedSelection.delete(key);
+    }
 
     const updatedKeys = Array.from(updatedSelection);
     const updatedRows = (rows ?? []).filter((r, i) => updatedSelection.has(getRowKey(r, i)));
@@ -553,7 +606,23 @@
                   <tr>
                     {#if selectable && headerRowIndex === 0}
                       <th class="fr-cell--fixed" role="columnheader">
-                        <span class="fr-sr-only">Sélectionner</span>
+                        {#if selectAll}
+                          {@const selectAllId = `${id ?? "table"}-select-all`}
+
+                          <div class="fr-checkbox-group fr-checkbox-group--sm">
+                            <input
+                              type="checkbox"
+                              id={selectAllId}
+                              checked={allRowsSelected}
+                              use:setIndeterminate={someRowsSelected}
+                              onchange={(event) =>
+                                handleSelectAll((event.currentTarget as HTMLInputElement).checked)}
+                            />
+                            <label class="fr-label" for={selectAllId}> Sélectionner tout </label>
+                          </div>
+                        {:else}
+                          <span class="fr-sr-only">Sélectionner</span>
+                        {/if}
                       </th>
                     {/if}
                     {#each row as cell, colIndex (colIndex)}
@@ -716,5 +785,47 @@
 
   .fr-sr-only {
     @include visually-hidden();
+  }
+
+  // Le DSFR ne fournit pas de style :indeterminate pour les checkboxes.
+  // On reprend le pattern :checked (fond bleu + bordure active) avec un tiret horizontal.
+  .fr-checkbox-group input[type="checkbox"]:indeterminate + label::before {
+    background-color: var(--background-active-blue-france);
+    background-image:
+      radial-gradient(
+        at 5px 4px,
+        transparent 4px,
+        var(--border-active-blue-france) 4px,
+        var(--border-active-blue-france) 5px,
+        transparent 6px
+      ),
+      linear-gradient(var(--border-active-blue-france), var(--border-active-blue-france)),
+      radial-gradient(
+        at calc(100% - 5px) 4px,
+        transparent 4px,
+        var(--border-active-blue-france) 4px,
+        var(--border-active-blue-france) 5px,
+        transparent 6px
+      ),
+      linear-gradient(var(--border-active-blue-france), var(--border-active-blue-france)),
+      radial-gradient(
+        at calc(100% - 5px) calc(100% - 4px),
+        transparent 4px,
+        var(--border-active-blue-france) 4px,
+        var(--border-active-blue-france) 5px,
+        transparent 6px
+      ),
+      linear-gradient(var(--border-active-blue-france), var(--border-active-blue-france)),
+      radial-gradient(
+        at 5px calc(100% - 4px),
+        transparent 4px,
+        var(--border-active-blue-france) 4px,
+        var(--border-active-blue-france) 5px,
+        transparent 6px
+      ),
+      linear-gradient(var(--border-active-blue-france), var(--border-active-blue-france)),
+      var(--data-uri-svg);
+
+    --data-uri-svg: url("data:image/svg+xml;charset=utf-8,<svg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 24 24'><path fill='%23f5f5fe' d='M5 11h14v2H5z'/></svg>");
   }
 </style>

--- a/src/lib/dsfr/DsfrTable.svelte
+++ b/src/lib/dsfr/DsfrTable.svelte
@@ -29,6 +29,9 @@
       itemsPerPage: { attribute: "items-per-page", type: "Array" },
       totalRows: { attribute: "total-rows", type: "Number" },
       rich: { attribute: "rich", type: "Boolean" },
+      selectable: { attribute: "selectable", type: "Boolean" },
+      rowKey: { attribute: "row-key", type: "String" },
+      selectedRowKeys: { attribute: "selected-row-keys", type: "Array" },
     },
   }}
 />
@@ -191,6 +194,22 @@
      * utiliser plutôt `Column.rich` au cas par cas.
      */
     rich?: boolean;
+    /**
+     * Active la variation sélectionnable : ajoute une colonne de cases à cocher en début de chaque ligne.
+     */
+    selectable?: boolean;
+    /**
+     * Nom de la clé dans les objets `Row` à utiliser comme identifiant unique pour la sélection.
+     * Si absent, l'index de la ligne est utilisé.
+     */
+    rowKey?: string;
+    /**
+     * Clés des lignes sélectionnées (mode contrôlé).
+     * Si fourni, le composant utilise cette valeur ; sinon, il gère sa propre sélection en interne.
+     */
+    selectedRowKeys?: (string | number)[];
+    /** Callback appelé lorsque la sélection change */
+    onselectionchanged?: (selectedKeys: (string | number)[], selectedRows: Row[]) => void;
   }
 
   let wrapperEl: HTMLDivElement | undefined = $state();
@@ -254,6 +273,10 @@
     onpagechanged,
     onrowsperpagechanged,
     rich = false,
+    selectable = false,
+    rowKey,
+    selectedRowKeys,
+    onselectionchanged,
   }: Props = $props();
 
   // Génère l'en-tête du tableau à partir de `columns` si fournies _(custom API)_, sinon à partir de `table` _(API DSFR)_.
@@ -292,14 +315,13 @@
       : (table?.tbodies ?? []),
   );
 
-  // En mode serveur (présence de `totalRows`), le parent gère le découpage : on affiche toutes les rows reçues.
-  // En mode client, le composant calcule lui-même le nombre total depuis les données.
+  // En mode serveur (présence de `totalRows`), le consommateur final gère le découpage, le composant lui affiche toutes les lignes reçues.
+  // En mode client (mode par défaut), le composant calcule lui-même le nombre total depuis les données.
   let isServerSide = $derived(totalRows !== undefined);
   let nbRows = $derived(isServerSide ? (totalRows ?? 0) : (computedTbodies[0]?.length ?? 0));
 
   let rowsPerPage = $state(itemsPerPage[0]);
   let currentPage = $state(1);
-
   let totalPages = $derived(Math.ceil(nbRows / rowsPerPage));
 
   // Calcule les lignes à afficher en fonction du mode (serveur/client) et de la pagination
@@ -352,6 +374,70 @@
 
     onpagechanged?.(page);
     $host()?.dispatchEvent(new CustomEvent("pagechanged", { detail: page }));
+  }
+
+  /**
+   * Récupère la clé d'une ligne.
+   * En l'absence de `rowKey`, l'index de la ligne sert d'identifiant.
+   *
+   * @param row - La ligne dont on veut obtenir la clé
+   * @param rowIndex - L'index de la ligne
+   *
+   * @returns La clé de la ligne (propriété `rowKey` ou index)
+   */
+  function getRowKey(row: Row, rowIndex: number): string | number {
+    if (rowKey && row[rowKey] != null) return row[rowKey] as string | number;
+
+    return rowIndex;
+  }
+
+  let internalSelectedKeys = $state<(string | number)[]>([]);
+
+  let isSelectionControlled = $derived(selectedRowKeys !== undefined);
+  let activeSelectedKeys = $derived(
+    isSelectionControlled ? (selectedRowKeys ?? []) : internalSelectedKeys,
+  );
+  let selectedKeysSet = $derived(new Set<string | number>(activeSelectedKeys));
+
+  /**
+   * Vérifie si une ligne est actuellement sélectionnée.
+   *
+   * @param row - La ligne à vérifier
+   * @param rowIndex - L'index de la ligne
+   *
+   * @returns `true` si la ligne est sélectionnée, `false` sinon
+   */
+  function isRowSelected(row: Row, rowIndex: number): boolean {
+    return selectedKeysSet.has(getRowKey(row, rowIndex));
+  }
+
+  /**
+   * Gère la sélection ou la désélection d'une ligne du tableau.
+   *
+   * Met à jour l'état interne de sélection (ou contrôlé de l'extérieur) et déclenche
+   * les callbacks et événements appropriés avec la liste mise à jour des clés sélectionnées
+   * et des lignes correspondantes.
+   *
+   * @param row - La ligne à sélectionner ou désélectionner
+   * @param rowIndex - L'index de la ligne dans le tableau
+   * @param checked - Indique si la ligne doit être sélectionnée (`true`) ou désélectionnée (`false`)
+   */
+  function handleRowSelection(row: Row, rowIndex: number, checked: boolean) {
+    const key = getRowKey(row, rowIndex);
+    const updatedSelection = new Set(activeSelectedKeys);
+
+    if (checked) updatedSelection.add(key);
+    else updatedSelection.delete(key);
+
+    const updatedKeys = Array.from(updatedSelection);
+    const updatedRows = (rows ?? []).filter((r, i) => updatedSelection.has(getRowKey(r, i)));
+
+    if (!isSelectionControlled) internalSelectedKeys = updatedKeys;
+
+    onselectionchanged?.(updatedKeys, updatedRows);
+    $host()?.dispatchEvent(
+      new CustomEvent("selectionchanged", { detail: { keys: updatedKeys, rows: updatedRows } }),
+    );
   }
 
   /**
@@ -463,15 +549,20 @@
 
             {#if computedThead.length}
               <thead>
-                {#each computedThead as row, rowIndex (rowIndex)}
+                {#each computedThead as row, headerRowIndex (headerRowIndex)}
                   <tr>
+                    {#if selectable && headerRowIndex === 0}
+                      <th class="fr-cell--fixed" role="columnheader">
+                        <span class="fr-sr-only">Sélectionner</span>
+                      </th>
+                    {/if}
                     {#each row as cell, colIndex (colIndex)}
                       <th
                         scope="col"
                         class={getCellClasses(
                           cell,
                           true,
-                          fixedFirstCellHead && rowIndex === 0 && colIndex === 0,
+                          fixedFirstCellHead && headerRowIndex === 0 && colIndex === 0,
                         )}
                       >
                         {cell.content}
@@ -485,7 +576,7 @@
             {#if nbRows === 0}
               <tbody>
                 <tr>
-                  <td colspan={computedThead[0]?.length ?? 1}>
+                  <td colspan={(computedThead[0]?.length ?? 1) + (selectable ? 1 : 0)}>
                     <slot name="empty"></slot>
                   </td>
                 </tr>
@@ -494,18 +585,47 @@
               {#each computedTbodies as tbody, tIndex (tIndex)}
                 <tbody>
                   {#each tIndex === 0 ? displayedRows : tbody as row, index (index)}
-                    {@const globalIndex =
+                    {@const rowIndex =
                       tIndex === 0 ? (currentPage - 1) * rowsPerPage + index : index}
+                    {@const originalRow =
+                      tIndex === 0 ? (rows?.[isServerSide ? index : rowIndex] ?? {}) : undefined}
+                    {@const selected =
+                      selectable && originalRow ? isRowSelected(originalRow, rowIndex) : undefined}
+
                     <tr
-                      id={id ? `${id}-row-key-${globalIndex}` : undefined}
-                      data-row-key={globalIndex}
+                      id={id ? `${id}-row-key-${rowIndex}` : undefined}
+                      data-row-key={rowIndex}
+                      aria-selected={selected}
                     >
+                      {#if selectable && tIndex === 0 && originalRow}
+                        {@const checkboxId = `${id ?? "table"}-select-checkbox-${rowIndex}`}
+
+                        <th class="fr-cell--fixed" scope="row">
+                          <div class="fr-checkbox-group fr-checkbox-group--sm">
+                            <input
+                              type="checkbox"
+                              data-fr-row-select="true"
+                              id={checkboxId}
+                              checked={selected}
+                              onchange={(event) =>
+                                handleRowSelection(
+                                  originalRow,
+                                  rowIndex,
+                                  (event.currentTarget as HTMLInputElement).checked,
+                                )}
+                            />
+                            <label class="fr-label" for={checkboxId}>
+                              Sélectionner la ligne {rowIndex + 1}
+                            </label>
+                          </div>
+                        </th>
+                      {/if}
                       {#each row as cell, cellIndex (cellIndex)}
                         {@const col = columns?.[cellIndex]}
                         <td
                           class={getCellClasses(cell)}
                           use:cellSlot={col && (rich || col.rich)
-                            ? `cell:${col.key}:${globalIndex}`
+                            ? `cell:${col.key}:${rowIndex}`
                             : null}
                         >
                           {cell.content}
@@ -582,7 +702,19 @@
   @use "src/lib/styles/mixins-dsfr.scss" as *;
   // DSFR Component styles
   @import "@gouvfr/dsfr/dist/component/table/table.main.min.css";
+  @import "@gouvfr/dsfr/dist/component/checkbox/checkbox.main.css";
 
   @include set-shadow-host();
   @include set-dsfr-sizing("table");
+
+  .fr-checkbox-group {
+    --checkbox-gap-sm: -1.25rem;
+
+    @include set-themeable-checkbox();
+    @include set-themeable-checkbox-sm();
+  }
+
+  .fr-sr-only {
+    @include visually-hidden();
+  }
 </style>

--- a/src/lib/styles/mixins-dsfr.scss
+++ b/src/lib/styles/mixins-dsfr.scss
@@ -142,7 +142,7 @@ $dash-height: var(--dash-height, 2px) !default;
 ///
 @mixin set-themeable-checkbox-sm() {
   &--sm {
-    --checkbox-gap: -1.5rem;
+    --checkbox-gap: var(--checkbox-gap-sm, -1.5rem);
     --checkmark-size: 1rem;
     --checkmark-scale: 1;
 

--- a/stories/demos/Table.stories.svelte
+++ b/stories/demos/Table.stories.svelte
@@ -172,6 +172,7 @@ En cas de besoin de personnalisation partielle _(une ou deux colonnes uniquement
       selectable={true}
       columns={citiesColumns}
       rows={citiesRows.slice(0, 5)}
+      select-all={_args.selectAll || undefined}
     ></dsfr-table>
   {/snippet}
 </Story>
@@ -185,6 +186,7 @@ En cas de besoin de personnalisation partielle _(une ou deux colonnes uniquement
       row-key="id"
       selected-row-keys={JSON.stringify(["ville-0", "ville-1", "ville-5"])}
       columns={citiesColumns}
+      select-all={_args.selectAll || undefined}
       rows={villesAvecId}
     ></dsfr-table>
   {/snippet}
@@ -205,6 +207,7 @@ En cas de besoin de personnalisation partielle _(une ou deux colonnes uniquement
       selectable={true}
       row-key="id"
       columns={citiesColumns}
+      select-all={_args.selectAll || undefined}
       rows={villesAvecId}
       selected-row-keys={JSON.stringify(selectedKeys)}
       onselectionchanged={(
@@ -216,6 +219,19 @@ En cas de besoin de personnalisation partielle _(une ou deux colonnes uniquement
         selectedKeys = event.detail.keys;
         selectedRowsCount = event.detail.rows.length;
       }}
+    ></dsfr-table>
+  {/snippet}
+</Story>
+
+<Story name="Sélectionnable avec checkbox 'Tout sélectionner'">
+  {#snippet template(_args: Args)}
+    <dsfr-table
+      id="table-selectable-all"
+      caption="Grandes villes de France"
+      selectable={true}
+      select-all={true}
+      columns={citiesColumns}
+      rows={citiesRows.slice(0, 8)}
     ></dsfr-table>
   {/snippet}
 </Story>

--- a/stories/demos/Table.stories.svelte
+++ b/stories/demos/Table.stories.svelte
@@ -33,6 +33,11 @@
     citiesRows.slice((serverPage - 1) * serverPerPage, serverPage * serverPerPage),
   );
 
+  // Données et état local pour les stories "sélectionnable" en mode `columns/rows`
+  const villesAvecId = citiesRows.slice(0, 8).map((row, i) => ({ ...row, id: `ville-${i}` }));
+  let selectedKeys = $state<(string | number)[]>([]);
+  let selectedRowsCount = $state(0);
+
   const { Story } = defineMeta({
     title: "Exemples/DSFR - Tableau",
     component: DsfrTable,
@@ -156,5 +161,61 @@ En cas de besoin de personnalisation partielle _(une ou deux colonnes uniquement
         </div>
       {/each}
     </dsfr-table>
+  {/snippet}
+</Story>
+
+<Story name="Sélectionnable (mode columns/rows)">
+  {#snippet template(_args: Args)}
+    <dsfr-table
+      id="table-selectable-rows"
+      caption="Grandes villes de France"
+      selectable={true}
+      columns={citiesColumns}
+      rows={citiesRows.slice(0, 5)}
+    ></dsfr-table>
+  {/snippet}
+</Story>
+
+<Story name="Sélectionnable avec rowKey et pré-sélection">
+  {#snippet template(_args: Args)}
+    <dsfr-table
+      id="table-selectable-rowkey"
+      caption="Grandes villes de France (clé = `id`)"
+      selectable={true}
+      row-key="id"
+      selected-row-keys={JSON.stringify(["ville-0", "ville-1", "ville-5"])}
+      columns={citiesColumns}
+      rows={villesAvecId}
+    ></dsfr-table>
+  {/snippet}
+</Story>
+
+<Story name="Sélectionnable contrôlée avec callback">
+  {#snippet template(_args: Args)}
+    <p class="fr-text--sm">
+      Sélection : {selectedKeys.length === 0 ? "aucune" : selectedKeys.join(", ")}
+      ({selectedRowsCount} Row{selectedRowsCount > 1 ? "s" : ""} renvoyée{selectedRowsCount > 1
+        ? "s"
+        : ""}
+      par le callback)
+    </p>
+    <dsfr-table
+      id="table-selectable-controlled"
+      caption="Grandes villes de France (sélection contrôlée)"
+      selectable={true}
+      row-key="id"
+      columns={citiesColumns}
+      rows={villesAvecId}
+      selected-row-keys={JSON.stringify(selectedKeys)}
+      onselectionchanged={(
+        event: CustomEvent<{
+          keys: (string | number)[];
+          rows: Record<string, unknown>[];
+        }>,
+      ) => {
+        selectedKeys = event.detail.keys;
+        selectedRowsCount = event.detail.rows.length;
+      }}
+    ></dsfr-table>
   {/snippet}
 </Story>

--- a/stories/dsfr/Table.stories.svelte
+++ b/stories/dsfr/Table.stories.svelte
@@ -128,6 +128,8 @@
     has-footer-pagination={args.hasFooterPagination || undefined}
     has-footer-buttons={args.hasFooterButtons || undefined}
     table={args.table}
+    selectable={args.selectable || undefined}
+    selected-row-keys={args.selectedRowKeys ? JSON.stringify(args.selectedRowKeys) : undefined}
   ></dsfr-table>
 {/snippet}
 
@@ -173,20 +175,17 @@
 -->
 
 <!--
-  TODO: nécessite un row header avec checkbox, non géré par le composant.
-<Story
-  name="Sélectionnable"
-  args={{ table: getSelectableTableArgs() }}
-/>
+  Note : les helpers DSFR `getSelectableTableArgs` / `getSelectableTableSelectedLineArgs`
+  préfixent eux-mêmes une colonne checkbox dans le tableau. Notre `DsfrTable` la génère
+  automatiquement via la prop `selectable`, on part donc de la table simple et on délègue
+  l'ajout de la colonne au composant.
 -->
+<Story name="Sélectionnable" args={{ selectable: true }} />
 
-<!--
-  TODO: idem "Sélectionnable" + état "ligne sélectionnée".
 <Story
   name="Sélectionnable avec ligne sélectionnée"
-  args={{ table: getSelectableTableSelectedLineArgs() }}
+  args={{ selectable: true, selectedRowKeys: [1] }}
 />
--->
 
 <!--
   TODO: nécessite la prise en charge de rowspan / colspan / headers, non géré par le composant.

--- a/stories/dsfr/Table.stories.svelte
+++ b/stories/dsfr/Table.stories.svelte
@@ -129,6 +129,7 @@
     has-footer-buttons={args.hasFooterButtons || undefined}
     table={args.table}
     selectable={args.selectable || undefined}
+    select-all={args.selectAll || undefined}
     selected-row-keys={args.selectedRowKeys ? JSON.stringify(args.selectedRowKeys) : undefined}
   ></dsfr-table>
 {/snippet}
@@ -186,6 +187,8 @@
   name="Sélectionnable avec ligne sélectionnée"
   args={{ selectable: true, selectedRowKeys: [1] }}
 />
+
+<Story name="Sélectionnable avec tout sélectionner" args={{ selectable: true, selectAll: true }} />
 
 <!--
   TODO: nécessite la prise en charge de rowspan / colspan / headers, non géré par le composant.


### PR DESCRIPTION
## Décrire les changements

Cette PR implémente la variation "Selectable Table" du composant `DsfrTable`.

La PR ajoute également une variation non prévue par le DSFR mais qui est utile pour les cas du LAB, à savoir l'ajout d'une checkbox permettant de sélectionner l'entièreté des lignes.

## Autres informations

<!-- Ajoutez ici tout autre commentaire ou toute autre information concernant cette Pull Request. -->
