### PR TITLE
[NPM] Autorise le "trusted publishing"

### DIFF
--- a/.github/workflows/publication-npm.yml
+++ b/.github/workflows/publication-npm.yml
@@ -1,6 +1,7 @@
 name: Publication du package sur NPM
 permissions:
   id-token: write # Pour permettre le --provenance de la publication npm https://docs.npmjs.com/generating-provenance-statements#publishing-packages-with-provenance-via-github-actions
+  contents: read
 
 on:
   release:
@@ -12,16 +13,17 @@ jobs:
 
     steps:
       - name: Git checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@v6
 
       - name: Récupérer la version
         run: echo "release_version=$(node -p "require('./package.json').version")" >> $GITHUB_ENV
 
       - name: Installer Node.js
-        uses: actions/setup-node@v3
+        uses: actions/setup-node@v6
         with:
           node-version: 24
           registry-url: "https://registry.npmjs.org/"
+          package-manager-cache: false
 
       - name: Installer les dépendances
         run: npm install -g "$(jq -r '.packageManager' package.json)" && pnpm install
@@ -43,8 +45,6 @@ jobs:
 
       - name: Publier sur NPM
         run: pnpm publish --provenance --access public --no-git-checks
-        env:
-          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
 
       - name: Installer et configurer la CLI de S3cmd
         uses: s3-actions/s3cmd@v1.10.0


### PR DESCRIPTION
On suit [cette doc](https://docs.npmjs.com/trusted-publishers#github-actions-configuration) pour activer le trusted publishing et ne plus avoir à gérer de tokens npm : meilleure sécurité.
