### PR TITLE
Documenter les évènements et les afficher dans les stories

### DIFF
--- a/.storybook/preview.ts
+++ b/.storybook/preview.ts
@@ -1,5 +1,6 @@
 import type { Preview, SvelteRenderer } from "@storybook/svelte";
 import { withThemeByClassName } from "@storybook/addon-themes";
+import { withActions } from "storybook/actions/decorator";
 
 import "./styles.fonts.css";
 import "./styles.scss";
@@ -7,6 +8,7 @@ import "./lab-anssi-themes.css";
 
 const preview: Preview = {
   decorators: [
+    withActions,
     withThemeByClassName<SvelteRenderer>({
       themes: {
         MonServiceSécurisé: "theme-mss",

--- a/src/lib/composants/CentreAide.svelte
+++ b/src/lib/composants/CentreAide.svelte
@@ -4,19 +4,16 @@
   import { run } from "svelte/legacy";
 
   import { fly } from "svelte/transition";
-  import { createEventDispatcher } from "svelte";
   import { srcAsset } from "$lib/assets/assets";
 
   interface Props {
     nomService: string;
     liens: string;
+    /** Callback appelé lorsqu'un lien est cliqué */
+    onlienclique?: (detail: { target: EventTarget & HTMLAnchorElement }) => void;
   }
 
-  let { nomService, liens }: Props = $props();
-
-  const emetEvenement = createEventDispatcher<{
-    lienclique: { target: EventTarget & HTMLAnchorElement };
-  }>();
+  let { nomService, liens, onlienclique }: Props = $props();
 
   let liensMisEnForme: { texte: string; href?: string; preventDefault?: boolean; id?: string }[] =
     $state([]);
@@ -75,7 +72,9 @@
             id={lien.id}
             onclick={(e) => {
               if (lien.preventDefault) e.preventDefault();
-              emetEvenement("lienclique", { target: e.currentTarget });
+              const detail = { target: e.currentTarget as EventTarget & HTMLAnchorElement };
+              onlienclique?.(detail);
+              $host()?.dispatchEvent(new CustomEvent("lienclique", { detail, bubbles: true }));
             }}>{lien.texte}</a
           >
         {/each}

--- a/src/lib/composants/FiltresCatalogue.svelte
+++ b/src/lib/composants/FiltresCatalogue.svelte
@@ -23,7 +23,9 @@
   function handleFilterClick(nouvelleValeur: string) {
     if (valeur === nouvelleValeur) return;
     valeur = nouvelleValeur;
-    $host().dispatchEvent(new CustomEvent("valeurachangee", { detail: nouvelleValeur }));
+    $host().dispatchEvent(
+      new CustomEvent("valeurachangee", { detail: nouvelleValeur, bubbles: true }),
+    );
   }
 </script>
 

--- a/src/lib/composants/MultiSelect.svelte
+++ b/src/lib/composants/MultiSelect.svelte
@@ -78,8 +78,12 @@
   let currentValues: string[] = $state(values || []);
   function handleChange(event: Event) {
     // REVIEW deprecate this event in favor of valueschanged
-    $host().dispatchEvent(new CustomEvent<string[]>("valuechanged", { detail: currentValues }));
-    $host().dispatchEvent(new CustomEvent<string[]>("valueschanged", { detail: currentValues }));
+    $host().dispatchEvent(
+      new CustomEvent<string[]>("valuechanged", { detail: currentValues, bubbles: true }),
+    );
+    $host().dispatchEvent(
+      new CustomEvent<string[]>("valueschanged", { detail: currentValues, bubbles: true }),
+    );
   }
 
   let summary = $state<HTMLElement>(undefined);

--- a/src/lib/composants/Reactions.svelte
+++ b/src/lib/composants/Reactions.svelte
@@ -11,8 +11,6 @@
 />
 
 <script lang="ts">
-  import { createEventDispatcher } from "svelte";
-
   type Reaction = {
     id: string;
     emoji: string;
@@ -28,6 +26,10 @@
     tooltipTexte?: string;
     /** Identifiant de l'infobulle */
     tooltipId?: string;
+    /** Callback appelé lorsqu'une réaction est ajoutée */
+    onajouteReaction?: (id: string) => void;
+    /** Callback appelé lorsqu'une réaction est supprimée */
+    onsupprimeReaction?: (id: string) => void;
   }
 
   let {
@@ -35,6 +37,8 @@
     variant = "tertiaire-sans-bordure",
     tooltipTexte,
     tooltipId,
+    onajouteReaction,
+    onsupprimeReaction,
   }: Props = $props();
 
   let tooltipShown = $state(false);
@@ -43,8 +47,6 @@
   let popoverElement: HTMLElement | null = null;
   let tooltipElement: HTMLElement | null = null;
   let triggerButton: HTMLElement | null = null;
-
-  let dispatch = createEventDispatcher<{ ajouteReaction: string; supprimeReaction: string }>();
 
   /**
    * Positionne dynamiquement le popover au-dessus du bouton déclencheur.
@@ -157,9 +159,11 @@
 
     // Émet un événement en fonction de l'état de la réaction
     if (estActif) {
-      dispatch("supprimeReaction", id);
+      onsupprimeReaction?.(id);
+      $host()?.dispatchEvent(new CustomEvent("supprimeReaction", { detail: id, bubbles: true }));
     } else {
-      dispatch("ajouteReaction", id);
+      onajouteReaction?.(id);
+      $host()?.dispatchEvent(new CustomEvent("ajouteReaction", { detail: id, bubbles: true }));
     }
 
     popoverElement.hidePopover();

--- a/src/lib/composants/blog/PageCrisp.svelte
+++ b/src/lib/composants/blog/PageCrisp.svelte
@@ -85,7 +85,7 @@
     if (contenu) scroll(window.location.hash);
   });
 
-  const ancreOuverte = (evenement: CustomEvent) => scroll(`#${evenement.detail}`);
+  const ancreOuverte = (ancre: string) => scroll(`#${ancre}`);
 
   onDestroy(() => {
     const lesSections = composant!.querySelectorAll("section");
@@ -96,10 +96,10 @@
 </script>
 
 <div bind:this={composant}>
-  <SommaireMobile {tableDesMatieres} on:ancreOuverte={ancreOuverte} />
+  <SommaireMobile {tableDesMatieres} onancreOuverte={ancreOuverte} />
 
   <article>
-    <SommaireBureau {tableDesMatieres} on:ancreOuverte={ancreOuverte} />
+    <SommaireBureau {tableDesMatieres} onancreOuverte={ancreOuverte} />
     <div class="contenu">
       <!-- eslint-disable-next-line svelte/no-at-html-tags-->
       {@html contenu}

--- a/src/lib/composants/blog/SommaireBureau.svelte
+++ b/src/lib/composants/blog/SommaireBureau.svelte
@@ -1,19 +1,16 @@
 <script lang="ts">
   import type { TableDesMatieres } from "$lib/types";
-  import { createEventDispatcher } from "svelte";
 
   interface Props {
     tableDesMatieres: TableDesMatieres;
+    /** Callback appelé lorsqu'une ancre est ouverte */
+    onancreOuverte?: (ancre: string) => void;
   }
 
-  let { tableDesMatieres }: Props = $props();
-
-  const emets = createEventDispatcher<{
-    ancreOuverte: string;
-  }>();
+  let { tableDesMatieres, onancreOuverte }: Props = $props();
 
   const ouvreEntree = (ancre: string) => {
-    emets("ancreOuverte", ancre);
+    onancreOuverte?.(ancre);
   };
 </script>
 

--- a/src/lib/composants/blog/SommaireMobile.svelte
+++ b/src/lib/composants/blog/SommaireMobile.svelte
@@ -1,24 +1,21 @@
 <script lang="ts">
   import type { TableDesMatieres } from "$lib/types";
-  import { createEventDispatcher } from "svelte";
   import IconeMenuLateral from "$lib/composants/blog/IconeMenuLateral.svelte";
   import IconeChevronBas from "$lib/composants/blog/IconeChevronBas.svelte";
 
   interface Props {
     tableDesMatieres: TableDesMatieres;
+    /** Callback appelé lorsqu'une ancre est ouverte */
+    onancreOuverte?: (ancre: string) => void;
   }
 
-  let { tableDesMatieres }: Props = $props();
+  let { tableDesMatieres, onancreOuverte }: Props = $props();
 
   let detailsElement: HTMLDetailsElement = $state();
 
-  const emets = createEventDispatcher<{
-    ancreOuverte: string;
-  }>();
-
   const ouvreEntree = (ancre: string) => {
     detailsElement.open = false;
-    emets("ancreOuverte", ancre);
+    onancreOuverte?.(ancre);
   };
 </script>
 

--- a/src/lib/dsfr/DsfrCheckbox.svelte
+++ b/src/lib/dsfr/DsfrCheckbox.svelte
@@ -33,7 +33,6 @@
 <script lang="ts">
   import type { Size } from "$lib/types";
   import { setThemeable } from "$lib/utilitaires";
-  import { createEventDispatcher } from "svelte";
   import { createFormValidation } from "$lib/utilitaires/createFormValidation.svelte";
   import { setIndeterminate } from "$lib/directives/actions.svelte.ts";
 
@@ -73,9 +72,9 @@
     internals?: ElementInternals;
     /** Attribut indeterminate de la checkbox */
     indeterminate?: boolean;
+    /** Callback appelé lors du changement d'état de la case à cocher */
+    onvaluechanged?: (checked: boolean) => void;
   }
-
-  const dispatch = createEventDispatcher();
 
   let {
     id,
@@ -93,6 +92,7 @@
     required,
     internals,
     indeterminate,
+    onvaluechanged,
   }: Props = $props();
 
   let formControlElement: HTMLInputElement;
@@ -125,7 +125,8 @@
     const target = event.target as HTMLInputElement;
     checked = target.checked;
 
-    dispatch("valuechanged", checked);
+    onvaluechanged?.(checked);
+    $host()?.dispatchEvent(new CustomEvent("valuechanged", { detail: checked, bubbles: true }));
   }
 
   /**

--- a/src/lib/dsfr/DsfrCheckboxesGroup.svelte
+++ b/src/lib/dsfr/DsfrCheckboxesGroup.svelte
@@ -121,7 +121,7 @@
    * Met à jour les valeurs et déclenche l'événement 'valueschanged'.
    */
   function handleChange() {
-    host.dispatchEvent(new CustomEvent("valueschanged", { detail: values }));
+    host.dispatchEvent(new CustomEvent("valueschanged", { detail: values, bubbles: true }));
   }
 
   /**

--- a/src/lib/dsfr/DsfrInput.svelte
+++ b/src/lib/dsfr/DsfrInput.svelte
@@ -51,7 +51,6 @@
 />
 
 <script lang="ts">
-  import { createEventDispatcher } from "svelte";
   import { getIconsStyleSheet, setIconClass, setThemeable } from "$lib/utilitaires";
   import { createFormValidation } from "$lib/utilitaires/createFormValidation.svelte";
   import DsfrMessagesGroup from "./DsfrMessagesGroup.svelte";
@@ -109,9 +108,9 @@
     step?: number;
     /** `ElementInternals` interface pour l'association du composant aux formulaires */
     internals?: ElementInternals;
+    /** Callback appelé lors du changement de valeur du champ de saisie */
+    onvaluechanged?: (value: string) => void;
   }
-
-  const dispatch = createEventDispatcher();
 
   let {
     id,
@@ -139,6 +138,7 @@
     required,
     step,
     internals,
+    onvaluechanged,
   }: Props = $props();
 
   let formControlElement: HTMLInputElement;
@@ -179,7 +179,10 @@
     const target = event.target as HTMLInputElement;
     value = target.value;
 
-    dispatch("valuechanged", target.value);
+    onvaluechanged?.(target.value);
+    $host()?.dispatchEvent(
+      new CustomEvent("valuechanged", { detail: target.value, bubbles: true }),
+    );
   }
 
   /**

--- a/src/lib/dsfr/DsfrRadio.svelte
+++ b/src/lib/dsfr/DsfrRadio.svelte
@@ -32,8 +32,6 @@
 <script lang="ts">
   import type { Accent, Size } from "$lib/types";
   import { setThemeable } from "$lib/utilitaires";
-  import { createEventDispatcher } from "svelte";
-
   setThemeable($host());
 
   type RadioSize = Extract<Size, "sm" | "md">;
@@ -66,9 +64,9 @@
     required?: boolean;
     /** `ElementInternals` interface pour l'association du composant aux formulaires */
     internals?: ElementInternals;
+    /** Callback appelé lors de la sélection du bouton radio */
+    onvaluechanged?: (value: string) => void;
   }
-
-  const dispatch = createEventDispatcher();
 
   let {
     id,
@@ -85,6 +83,7 @@
     form,
     required,
     internals,
+    onvaluechanged,
   }: Props = $props();
 
   const richClass = $derived.by(() => {
@@ -94,7 +93,10 @@
 
   function handleChange(event: Event) {
     const target = event.target as HTMLInputElement;
-    dispatch("valuechanged", target.value);
+    onvaluechanged?.(target.value);
+    $host()?.dispatchEvent(
+      new CustomEvent("valuechanged", { detail: target.value, bubbles: true }),
+    );
   }
 </script>
 

--- a/src/lib/dsfr/DsfrRadiosGroup.svelte
+++ b/src/lib/dsfr/DsfrRadiosGroup.svelte
@@ -127,7 +127,7 @@
    * Met à jour la valeur et déclenche l'événement 'valuechanged'.
    */
   function handleChange() {
-    host.dispatchEvent(new CustomEvent("valuechanged", { detail: value }));
+    host.dispatchEvent(new CustomEvent("valuechanged", { detail: value, bubbles: true }));
   }
 
   /**

--- a/src/lib/dsfr/DsfrRange.svelte
+++ b/src/lib/dsfr/DsfrRange.svelte
@@ -30,7 +30,6 @@
 
 <script lang="ts">
   import { untrack } from "svelte";
-  import { createEventDispatcher } from "svelte";
   import type { Size, Status } from "$lib/types";
   import { setThemeable } from "$lib/utilitaires";
 
@@ -84,6 +83,10 @@
     errorMessage?: string;
     /** Permet de masquer le texte de l'élément 'output' */
     hideOutputLabel?: boolean;
+    /** Callback appelé lors du changement de la valeur principale */
+    onvaluechanged?: (value: number) => void;
+    /** Callback appelé lors du changement de la seconde valeur (curseur double) */
+    onvalue2changed?: (value: number) => void;
   }
 
   let {
@@ -109,9 +112,9 @@
     status = "default",
     errorMessage,
     hideOutputLabel = false,
+    onvaluechanged,
+    onvalue2changed,
   }: Props = $props();
-
-  const dispatch = createEventDispatcher();
 
   const decorate = (val: number | string) => `${prefix ?? ""}${val}${suffix ?? ""}`;
 
@@ -189,11 +192,13 @@
     const newVal = parseFloat((e.target as HTMLInputElement).value);
     value = newVal;
 
-    dispatch("valuechanged", newVal);
+    onvaluechanged?.(newVal);
+    $host()?.dispatchEvent(new CustomEvent("valuechanged", { detail: newVal, bubbles: true }));
 
     if (isDouble && value2 < newVal) {
       untrack(() => (value2 = newVal));
-      dispatch("value2changed", newVal);
+      onvalue2changed?.(newVal);
+      $host()?.dispatchEvent(new CustomEvent("value2changed", { detail: newVal, bubbles: true }));
     }
   }
 
@@ -202,11 +207,13 @@
     const newVal = parseFloat((e.target as HTMLInputElement).value);
     value2 = newVal;
 
-    dispatch("value2changed", newVal);
+    onvalue2changed?.(newVal);
+    $host()?.dispatchEvent(new CustomEvent("value2changed", { detail: newVal, bubbles: true }));
 
     if (isDouble && value > newVal) {
       untrack(() => (value = newVal));
-      dispatch("valuechanged", newVal);
+      onvaluechanged?.(newVal);
+      $host()?.dispatchEvent(new CustomEvent("valuechanged", { detail: newVal, bubbles: true }));
     }
   }
 </script>

--- a/src/lib/dsfr/DsfrSearch.svelte
+++ b/src/lib/dsfr/DsfrSearch.svelte
@@ -36,8 +36,6 @@
   import type { Size } from "$lib/types";
   import { setThemeable } from "$lib/utilitaires";
   import { createFormValidation } from "$lib/utilitaires/createFormValidation.svelte";
-  import { createEventDispatcher } from "svelte";
-
   setThemeable($host());
 
   type SearchSize = Extract<Size, "md" | "lg">;
@@ -76,9 +74,11 @@
     required?: boolean;
     /** `ElementInternals` interface pour l'association du composant aux formulaires */
     internals?: ElementInternals;
+    /** Callback appelé lors du changement de valeur du champ de recherche */
+    onvaluechanged?: (value: string) => void;
+    /** Callback appelé lors de la soumission de la recherche */
+    onsearch?: (value: string) => void;
   }
-
-  const dispatch = createEventDispatcher();
 
   let {
     inputId,
@@ -98,6 +98,8 @@
     readonly,
     required,
     internals,
+    onvaluechanged,
+    onsearch,
   }: Props = $props();
 
   let formControlElement: HTMLInputElement;
@@ -117,7 +119,10 @@
 
     value = target.value;
 
-    dispatch("valuechanged", target.value);
+    onvaluechanged?.(target.value);
+    $host()?.dispatchEvent(
+      new CustomEvent("valuechanged", { detail: target.value, bubbles: true }),
+    );
   }
 
   /**
@@ -135,7 +140,8 @@
       return;
     }
 
-    dispatch("search", value);
+    onsearch?.(value);
+    $host()?.dispatchEvent(new CustomEvent("search", { detail: value, bubbles: true }));
   }
 
   /**

--- a/src/lib/dsfr/DsfrSegmented.svelte
+++ b/src/lib/dsfr/DsfrSegmented.svelte
@@ -18,8 +18,6 @@
 <script lang="ts">
   import type { Size } from "$lib/types";
   import { withIconsStyleSheet, setIconClass, setThemeable } from "$lib/utilitaires";
-  import { createEventDispatcher } from "svelte";
-
   setThemeable($host());
 
   type SegmentedSize = Extract<Size, "sm" | "md">;
@@ -50,9 +48,9 @@
     elements: Segmented[];
     /** Valeur des segments */
     value?: string | number;
+    /** Callback appelé lors du changement de segment actif */
+    onvaluechanged?: (value: string | number) => void;
   }
-
-  const dispatch = createEventDispatcher();
 
   let {
     size = "md",
@@ -63,6 +61,7 @@
     hasIcon = false,
     elements = [],
     value,
+    onvaluechanged,
   }: Props = $props();
 
   // `checked` sert de fallback si `value` n'est pas fourni
@@ -140,7 +139,10 @@
    * @param {Event} event - L'événement de changement déclenché par l'élément DOM
    */
   function handleChange(event: Event) {
-    dispatch("valuechanged", currentValue);
+    onvaluechanged?.(currentValue);
+    $host()?.dispatchEvent(
+      new CustomEvent("valuechanged", { detail: currentValue, bubbles: true }),
+    );
   }
 </script>
 

--- a/src/lib/dsfr/DsfrSelect.svelte
+++ b/src/lib/dsfr/DsfrSelect.svelte
@@ -36,7 +36,6 @@
 
 <script lang="ts">
   import { setThemeable } from "$lib/utilitaires";
-  import { createEventDispatcher } from "svelte";
   import { createFormValidation } from "$lib/utilitaires/createFormValidation.svelte";
   import DsfrMessagesGroup from "./DsfrMessagesGroup.svelte";
 
@@ -92,8 +91,6 @@
     /** Attribut name du champs de saisie */
     name?: string;
   }
-
-  const dispatch = createEventDispatcher();
 
   let {
     id,
@@ -151,8 +148,10 @@
     const target = event.target as HTMLSelectElement;
     value = target.value;
 
-    dispatch("valuechanged", target.value);
     onvaluechanged?.(target.value);
+    $host()?.dispatchEvent(
+      new CustomEvent("valuechanged", { detail: target.value, bubbles: true }),
+    );
   }
 
   /**

--- a/src/lib/dsfr/DsfrTable.svelte
+++ b/src/lib/dsfr/DsfrTable.svelte
@@ -370,7 +370,9 @@
     currentPage = 1;
 
     onrowsperpagechanged?.(newValue);
-    $host()?.dispatchEvent(new CustomEvent("rowsperpagechanged", { detail: newValue }));
+    $host()?.dispatchEvent(
+      new CustomEvent("rowsperpagechanged", { detail: newValue, bubbles: true }),
+    );
   }
 
   /**
@@ -383,7 +385,7 @@
     currentPage = page;
 
     onpagechanged?.(page);
-    $host()?.dispatchEvent(new CustomEvent("pagechanged", { detail: page }));
+    $host()?.dispatchEvent(new CustomEvent("pagechanged", { detail: page, bubbles: true }));
   }
 
   /**
@@ -464,7 +466,10 @@
 
     onselectionchanged?.(updatedKeys, updatedRows);
     $host()?.dispatchEvent(
-      new CustomEvent("selectionchanged", { detail: { keys: updatedKeys, rows: updatedRows } }),
+      new CustomEvent("selectionchanged", {
+        detail: { keys: updatedKeys, rows: updatedRows },
+        bubbles: true,
+      }),
     );
   }
 
@@ -489,7 +494,10 @@
 
     onselectionchanged?.(updatedKeys, updatedRows);
     $host()?.dispatchEvent(
-      new CustomEvent("selectionchanged", { detail: { keys: updatedKeys, rows: updatedRows } }),
+      new CustomEvent("selectionchanged", {
+        detail: { keys: updatedKeys, rows: updatedRows },
+        bubbles: true,
+      }),
     );
   }
 

--- a/src/lib/dsfr/DsfrTabnav.svelte
+++ b/src/lib/dsfr/DsfrTabnav.svelte
@@ -71,7 +71,9 @@
 
     event.preventDefault();
 
-    $host().dispatchEvent(new CustomEvent("linkclicked", { detail: { index, link } }));
+    $host().dispatchEvent(
+      new CustomEvent("linkclicked", { detail: { index, link }, bubbles: true }),
+    );
   }
 </script>
 

--- a/src/lib/dsfr/DsfrTabs.svelte
+++ b/src/lib/dsfr/DsfrTabs.svelte
@@ -103,7 +103,9 @@
   function selectTab(index: number) {
     activeIndex = index;
 
-    $host().dispatchEvent(new CustomEvent("tabchanged", { detail: { index, tab: tabs[index] } }));
+    $host().dispatchEvent(
+      new CustomEvent("tabchanged", { detail: { index, tab: tabs[index] }, bubbles: true }),
+    );
   }
 </script>
 

--- a/src/lib/dsfr/DsfrTag.svelte
+++ b/src/lib/dsfr/DsfrTag.svelte
@@ -22,8 +22,6 @@
 <script lang="ts">
   import type { Accent, Size } from "$lib/types";
   import { withIconsStyleSheet, setIconClass, setThemeable } from "$lib/utilitaires";
-  import { createEventDispatcher } from "svelte";
-
   setThemeable($host());
 
   type TagSize = Extract<Size, "sm" | "md">;
@@ -53,6 +51,10 @@
     accent?: Accent;
     /** Attribut id du tag */
     id?: string;
+    /** Callback appelé lorsque le tag est sélectionné */
+    onselected?: (id: string) => void;
+    /** Callback appelé lorsque le tag est désélectionné */
+    onunselected?: (id: string) => void;
   }
 
   const {
@@ -68,6 +70,8 @@
     icon,
     accent,
     id,
+    onselected,
+    onunselected,
   }: Props = $props();
 
   const markup: Markup = $derived.by(() => {
@@ -91,16 +95,17 @@
   });
   const sizeClass = $derived(`fr-tag--${size}`);
 
-  let dispatch = createEventDispatcher<{ selected: string; unselected: string }>();
   const onpressed = (event: MouseEvent) => {
     let button = event.target as HTMLButtonElement;
     let ariaPressed = button.ariaPressed;
     const isPressed = ariaPressed === "true";
     button.ariaPressed = (!isPressed).toString();
     if (isPressed) {
-      dispatch("unselected", button.id);
+      onunselected?.(button.id);
+      $host()?.dispatchEvent(new CustomEvent("unselected", { detail: button.id, bubbles: true }));
     } else {
-      dispatch("selected", button.id);
+      onselected?.(button.id);
+      $host()?.dispatchEvent(new CustomEvent("selected", { detail: button.id, bubbles: true }));
     }
   };
 </script>

--- a/src/lib/dsfr/DsfrTagsGroup.svelte
+++ b/src/lib/dsfr/DsfrTagsGroup.svelte
@@ -15,8 +15,6 @@
 <script lang="ts">
   import type { Accent, Size } from "$lib/types";
   import { withIconsStyleSheet, setThemeable } from "$lib/utilitaires";
-  import { createEventDispatcher } from "svelte";
-
   setThemeable($host());
 
   type TagsGroupSize = Extract<Size, "sm" | "md">;
@@ -47,9 +45,21 @@
     groupMarkup?: GroupMarkup;
     /** Si true, ajoute une icone dans le titre des onglets */
     hasIcon?: boolean;
+    /** Callback appelé lorsqu'un tag est sélectionné */
+    onselected?: (id: string) => void;
+    /** Callback appelé lorsqu'un tag est désélectionné */
+    onunselected?: (id: string) => void;
   }
 
-  let { tags, type = "default", size = "md", groupMarkup, hasIcon }: Props = $props();
+  let {
+    tags,
+    type = "default",
+    size = "md",
+    groupMarkup,
+    hasIcon,
+    onselected,
+    onunselected,
+  }: Props = $props();
 
   const dissmissClass = $derived.by(() => type === "dismissible" && "fr-tag--dismiss");
   const sizeClass = $derived(`fr-tags-group--${size}`);
@@ -66,17 +76,17 @@
     }
   });
 
-  let dispatch = createEventDispatcher<{ selected: string; unselected: string }>();
-
   const onpressed = (event: MouseEvent) => {
     let button = event.target as HTMLButtonElement;
     let ariaPressed = button.ariaPressed;
     const isPressed = ariaPressed === "true";
     button.ariaPressed = (!isPressed).toString();
     if (isPressed) {
-      dispatch("unselected", button.id);
+      onunselected?.(button.id);
+      $host()?.dispatchEvent(new CustomEvent("unselected", { detail: button.id, bubbles: true }));
     } else {
-      dispatch("selected", button.id);
+      onselected?.(button.id);
+      $host()?.dispatchEvent(new CustomEvent("selected", { detail: button.id, bubbles: true }));
     }
   };
 </script>

--- a/src/lib/dsfr/DsfrTextarea.svelte
+++ b/src/lib/dsfr/DsfrTextarea.svelte
@@ -39,7 +39,6 @@
   import type { HTMLTextareaAttributes } from "svelte/elements";
   import { setThemeable } from "$lib/utilitaires";
   import { createFormValidation } from "$lib/utilitaires/createFormValidation.svelte";
-  import { createEventDispatcher } from "svelte";
   import DsfrMessagesGroup from "./DsfrMessagesGroup.svelte";
 
   setThemeable($host());
@@ -85,9 +84,9 @@
     required?: boolean;
     /** `ElementInternals` interface pour l'association du composant aux formulaires */
     internals?: ElementInternals;
+    /** Callback appelé lors du changement de valeur du champ de saisie */
+    onvaluechanged?: (value: string) => void;
   }
-
-  const dispatch = createEventDispatcher();
 
   let {
     id,
@@ -110,6 +109,7 @@
     readonly,
     required,
     internals,
+    onvaluechanged,
   }: Props = $props();
 
   let formControlElement: HTMLTextAreaElement;
@@ -137,7 +137,10 @@
     const target = event.target as HTMLTextAreaElement;
     value = target.value;
 
-    dispatch("valuechanged", target.value);
+    onvaluechanged?.(target.value);
+    $host()?.dispatchEvent(
+      new CustomEvent("valuechanged", { detail: target.value, bubbles: true }),
+    );
   }
 
   /**

--- a/src/lib/dsfr/DsfrToggle.svelte
+++ b/src/lib/dsfr/DsfrToggle.svelte
@@ -21,7 +21,6 @@
 
 <script lang="ts">
   import { setThemeable } from "$lib/utilitaires";
-  import { createEventDispatcher } from "svelte";
   import DsfrMessagesGroup from "./DsfrMessagesGroup.svelte";
 
   setThemeable($host());
@@ -56,9 +55,9 @@
     form?: string;
     /** Attribut required de la checkbox */
     required?: boolean;
+    /** Callback appelé lors du changement d'état de l'interrupteur */
+    onvaluechanged?: (checked: boolean) => void;
   }
-
-  const dispatch = createEventDispatcher();
 
   let {
     id,
@@ -75,6 +74,7 @@
     validMessage,
     form,
     required,
+    onvaluechanged,
     ...restProps
   }: Props = $props();
 
@@ -89,7 +89,10 @@
 
   function handleChange(event: Event) {
     const target = event.target as HTMLInputElement;
-    dispatch("valuechanged", target.checked);
+    onvaluechanged?.(target.checked);
+    $host()?.dispatchEvent(
+      new CustomEvent("valuechanged", { detail: target.checked, bubbles: true }),
+    );
   }
 </script>
 

--- a/stories/composants/CentreAide.stories.svelte
+++ b/stories/composants/CentreAide.stories.svelte
@@ -26,6 +26,21 @@
         },
       ]),
     },
+    argTypes: {
+      onlienclique: {
+        description:
+          "Déclenché au clic sur un lien du centre d'aide.<br>" +
+          "`detail: { target: HTMLAnchorElement }`",
+        table: {
+          category: "Événements",
+          type: { summary: "CustomEvent<{ target: HTMLAnchorElement }>" },
+        },
+        control: false,
+      },
+    },
+    parameters: {
+      actions: { handles: ["lienclique"] },
+    },
     render: template,
   });
 

--- a/stories/composants/FiltresCatalogue.stories.svelte
+++ b/stories/composants/FiltresCatalogue.stories.svelte
@@ -18,6 +18,19 @@
         { libelle: "Explorer les formations", valeur: "category5", icone: Success },
       ],
     },
+    argTypes: {
+      onvaleurachangee: {
+        description: "Déclenché lors du changement de filtre sélectionné.<br>" + "`detail: string`",
+        table: {
+          category: "Événements",
+          type: { summary: "CustomEvent<string>" },
+        },
+        control: false,
+      },
+    },
+    parameters: {
+      actions: { handles: ["valeurachangee"] },
+    },
     render: template,
   });
 

--- a/stories/composants/MultiSelect.stories.svelte
+++ b/stories/composants/MultiSelect.stories.svelte
@@ -26,6 +26,29 @@
       values: {
         control: { type: "array" },
       },
+      onvaluechanged: {
+        description:
+          "Déclenché lors du changement de la dernière valeur sélectionnée ou désélectionnée.<br>" +
+          "`detail: string[]`",
+        table: {
+          category: "Événements",
+          type: { summary: "CustomEvent<string[]>" },
+        },
+        control: false,
+      },
+      onvalueschanged: {
+        description:
+          "Déclenché lors du changement de l'ensemble des valeurs sélectionnées.<br>" +
+          "`detail: string[]`",
+        table: {
+          category: "Événements",
+          type: { summary: "CustomEvent<string[]>" },
+        },
+        control: false,
+      },
+    },
+    parameters: {
+      actions: { handles: ["valuechanged", "valueschanged"] },
     },
     render: template,
   });

--- a/stories/composants/Reactions.stories.svelte
+++ b/stories/composants/Reactions.stories.svelte
@@ -17,7 +17,26 @@
       tooltipTexte: "Ajouter une réaction",
       tooltipId: "tooltipReactions",
     },
+    argTypes: {
+      onajouteReaction: {
+        description: "Déclenché lorsqu'une réaction est ajoutée.<br>" + "`detail: string`",
+        table: {
+          category: "Événements",
+          type: { summary: "CustomEvent<string>" },
+        },
+        control: false,
+      },
+      onsupprimeReaction: {
+        description: "Déclenché lorsqu'une réaction est retirée.<br>" + "`detail: string`",
+        table: {
+          category: "Événements",
+          type: { summary: "CustomEvent<string>" },
+        },
+        control: false,
+      },
+    },
     parameters: {
+      actions: { handles: ["ajouteReaction", "supprimeReaction"] },
       layout: "centered",
     },
     render: template,

--- a/stories/dsfr/Checkbox.stories.svelte
+++ b/stories/dsfr/Checkbox.stories.svelte
@@ -26,9 +26,19 @@
         control: "boolean",
         description: "Attribut indeterminate de la checkbox",
       },
+      onvaluechanged: {
+        description:
+          "Déclenché lors du changement d'état de la case à cocher.<br>" + "`detail: boolean`",
+        table: {
+          category: "Événements",
+          type: { summary: "CustomEvent<boolean>" },
+        },
+        control: false,
+      },
     },
     args: checkboxArgs,
     parameters: {
+      actions: { handles: ["valuechanged"] },
       docs: {
         source: {
           transform: webComponentSourceCode("dsfr-checkbox"),

--- a/stories/dsfr/CheckboxesGroup.stories.svelte
+++ b/stories/dsfr/CheckboxesGroup.stories.svelte
@@ -35,9 +35,21 @@
   const { Story } = defineMeta({
     title: "Composants/dsfr/Checkboxes Group",
     component: DsfrCheckboxesGroup,
-    argTypes: checkboxesGroupArgTypes,
+    argTypes: {
+      ...checkboxesGroupArgTypes,
+      onvalueschanged: {
+        description:
+          "Déclenché lors du changement des valeurs sélectionnées.<br>" + "`detail: string[]`",
+        table: {
+          category: "Événements",
+          type: { summary: "CustomEvent<string[]>" },
+        },
+        control: false,
+      },
+    },
     args,
     parameters: {
+      actions: { handles: ["valueschanged"] },
       docs: {
         source: {
           transform: webComponentSourceCode("dsfr-checkboxes-group"),

--- a/stories/dsfr/Dropdown.stories.svelte
+++ b/stories/dsfr/Dropdown.stories.svelte
@@ -26,6 +26,16 @@
         control: false,
         table: { category: "Slots" },
       },
+      onitemclicked: {
+        description:
+          "Déclenché au clic sur un élément du menu déroulant.<br>" +
+          "`detail: { item: DropdownItem, index: number }`",
+        table: {
+          category: "Événements",
+          type: { summary: "CustomEvent<{ item: DropdownItem, index: number }>" },
+        },
+        control: false,
+      },
     },
     args: {
       id: "dropdown-id",
@@ -47,6 +57,7 @@
       ],
     },
     parameters: {
+      actions: { handles: ["itemclicked"] },
       docs: {
         source: {
           transform: webComponentSourceCode("dsfr-dropdown"),

--- a/stories/dsfr/Header.stories.svelte
+++ b/stories/dsfr/Header.stories.svelte
@@ -83,6 +83,14 @@
         control: false,
         table: { category: "Slots" },
       },
+      ontoolLinkClick: {
+        description: "Déclenché au clic sur un lien d'accès rapide.<br>" + "`detail: ToolLink`",
+        table: {
+          category: "Événements",
+          type: { summary: "CustomEvent<ToolLink>" },
+        },
+        control: false,
+      },
       fluid: {
         control: "boolean",
         description: "Permet de définir le conteneur comme 'fluide' ou non",
@@ -176,6 +184,7 @@
       ],
     },
     parameters: {
+      actions: { handles: ["toolLinkClick"] },
       docs: {
         source: {
           transform: webComponentSourceCode("dsfr-header"),

--- a/stories/dsfr/Input.stories.svelte
+++ b/stories/dsfr/Input.stories.svelte
@@ -32,9 +32,19 @@
         },
         table: { category: "message" },
       },
+      onvaluechanged: {
+        description:
+          "Déclenché lors du changement de valeur du champ de saisie.<br>" + "`detail: string`",
+        table: {
+          category: "Événements",
+          type: { summary: "CustomEvent<string>" },
+        },
+        control: false,
+      },
     },
     args: inputArgs,
     parameters: {
+      actions: { handles: ["valuechanged"] },
       docs: {
         source: {
           transform: webComponentSourceCode("dsfr-input"),

--- a/stories/dsfr/Pagination.stories.svelte
+++ b/stories/dsfr/Pagination.stories.svelte
@@ -21,9 +21,20 @@
   const { Story } = defineMeta({
     title: "Composants/dsfr/Pagination",
     component: DsfrPagination,
-    argTypes: camelCaseProps(paginationArgTypes),
+    argTypes: {
+      ...camelCaseProps(paginationArgTypes),
+      onpagechange: {
+        description: "Déclenché lors du changement de page.",
+        table: {
+          category: "Événements",
+          type: { summary: "(page: number) => void" },
+        },
+        control: false,
+      },
+    },
     args: camelCaseProps(paginationArgs),
     parameters: {
+      actions: { handles: ["pagechange"] },
       docs: {
         source: {
           transform: webComponentSourceCode("dsfr-pagination"),

--- a/stories/dsfr/Radio.stories.svelte
+++ b/stories/dsfr/Radio.stories.svelte
@@ -13,9 +13,20 @@
   const { Story } = defineMeta({
     title: "Composants/dsfr/Radio",
     component: DsfrRadio,
-    argTypes: radioArgTypes,
+    argTypes: {
+      ...radioArgTypes,
+      onvaluechanged: {
+        description: "Déclenché lors de la sélection du bouton radio.<br>" + "`detail: string`",
+        table: {
+          category: "Événements",
+          type: { summary: "CustomEvent<string>" },
+        },
+        control: false,
+      },
+    },
     args: radioArgs,
     parameters: {
+      actions: { handles: ["valuechanged"] },
       docs: {
         source: {
           transform: webComponentSourceCode("dsfr-radio"),

--- a/stories/dsfr/RadiosGroup.stories.svelte
+++ b/stories/dsfr/RadiosGroup.stories.svelte
@@ -16,9 +16,21 @@
   const { Story } = defineMeta({
     title: "Composants/dsfr/Radios Group",
     component: DsfrRadiosGroup,
-    argTypes: radiosGroupArgTypes,
+    argTypes: {
+      ...radiosGroupArgTypes,
+      onvaluechanged: {
+        description:
+          "Déclenché lors du changement de la valeur sélectionnée.<br>" + "`detail: string`",
+        table: {
+          category: "Événements",
+          type: { summary: "CustomEvent<string>" },
+        },
+        control: false,
+      },
+    },
     args: { radios: getRadiosGroupData(), ...radiosGroupArgs },
     parameters: {
+      actions: { handles: ["valuechanged"] },
       docs: {
         source: {
           transform: webComponentSourceCode("dsfr-radios-group"),

--- a/stories/dsfr/Range.stories.svelte
+++ b/stories/dsfr/Range.stories.svelte
@@ -20,9 +20,29 @@
         control: false,
         table: { category: "Slots" },
       },
+      onvaluechanged: {
+        description:
+          "Déclenché lors du changement de la valeur principale.<br>" + "`detail: number`",
+        table: {
+          category: "Événements",
+          type: { summary: "CustomEvent<number>" },
+        },
+        control: false,
+      },
+      onvalue2changed: {
+        description:
+          "Déclenché lors du changement de la seconde valeur (curseur double).<br>" +
+          "`detail: number`",
+        table: {
+          category: "Événements",
+          type: { summary: "CustomEvent<number>" },
+        },
+        control: false,
+      },
     },
     args: rangeArgs,
     parameters: {
+      actions: { handles: ["valuechanged", "value2changed"] },
       docs: {
         source: {
           transform: webComponentSourceCode("dsfr-range"),

--- a/stories/dsfr/Search.stories.svelte
+++ b/stories/dsfr/Search.stories.svelte
@@ -13,9 +13,29 @@
   const { Story } = defineMeta({
     title: "Composants/dsfr/Search",
     component: DsfrSearch,
-    argTypes: searchArgTypes,
+    argTypes: {
+      ...searchArgTypes,
+      onvaluechanged: {
+        description:
+          "Déclenché lors du changement de valeur du champ de recherche.<br>" + "`detail: string`",
+        table: {
+          category: "Événements",
+          type: { summary: "CustomEvent<string>" },
+        },
+        control: false,
+      },
+      onsearch: {
+        description: "Déclenché lors de la soumission de la recherche.<br>" + "`detail: string`",
+        table: {
+          category: "Événements",
+          type: { summary: "CustomEvent<string>" },
+        },
+        control: false,
+      },
+    },
     args: searchArgs,
     parameters: {
+      actions: { handles: ["valuechanged", "search"] },
       docs: {
         source: {
           transform: webComponentSourceCode("dsfr-search"),

--- a/stories/dsfr/Segmented.stories.svelte
+++ b/stories/dsfr/Segmented.stories.svelte
@@ -13,9 +13,21 @@
   const { Story } = defineMeta({
     title: "Composants/dsfr/Segmented",
     component: DsfrSegmented,
-    argTypes: segmentedArgTypes,
+    argTypes: {
+      ...segmentedArgTypes,
+      onvaluechanged: {
+        description:
+          "Déclenché lors du changement de segment actif.<br>" + "`detail: number | string`",
+        table: {
+          category: "Événements",
+          type: { summary: "CustomEvent<number | string>" },
+        },
+        control: false,
+      },
+    },
     args: { ...segmentedArgs, value: 1 },
     parameters: {
+      actions: { handles: ["valuechanged"] },
       docs: {
         source: {
           transform: webComponentSourceCode("dsfr-segmented"),

--- a/stories/dsfr/Select.stories.svelte
+++ b/stories/dsfr/Select.stories.svelte
@@ -38,9 +38,19 @@
         control: false,
         table: { category: "Slots" },
       },
+      onvaluechanged: {
+        description:
+          "Déclenché lors du changement de valeur de la liste déroulante.<br>" + "`detail: string`",
+        table: {
+          category: "Événements",
+          type: { summary: "CustomEvent<string>" },
+        },
+        control: false,
+      },
     },
     args: selectArgs,
     parameters: {
+      actions: { handles: ["valuechanged"] },
       docs: {
         source: {
           transform: webComponentSourceCode("dsfr-select"),

--- a/stories/dsfr/Table.stories.svelte
+++ b/stories/dsfr/Table.stories.svelte
@@ -86,9 +86,37 @@
         control: false,
         table: { category: "Slots" },
       },
+      onpagechanged: {
+        description: "Déclenché lors du changement de page.<br>" + "`detail: number`",
+        table: {
+          category: "Événements",
+          type: { summary: "CustomEvent<number>" },
+        },
+        control: false,
+      },
+      onrowsperpagechanged: {
+        description:
+          "Déclenché lors du changement du nombre de lignes par page.<br>" + "`detail: number`",
+        table: {
+          category: "Événements",
+          type: { summary: "CustomEvent<number>" },
+        },
+        control: false,
+      },
+      onselectionchanged: {
+        description:
+          "Déclenché lors du changement de la sélection des lignes.<br>" +
+          "`detail: { keys: (string | number)[], rows: Row[] }`",
+        table: {
+          category: "Événements",
+          type: { summary: "CustomEvent<{ keys: (string | number)[], rows: Row[] }>" },
+        },
+        control: false,
+      },
     },
     args: tableArgs,
     parameters: {
+      actions: { handles: ["pagechanged", "rowsperpagechanged", "selectionchanged"] },
       docs: {
         description: {
           component: `Les stories présentes dans cette page sont issues de la documentation du DSFR.<br/> Elles ne couvrent que les cas d'usage de base du composant **Table** tel que présentés dans le DSFR, et ne mettent pas en avant les fonctionnalités plus avancées du composant _(ex: cellules avec contenus riches, en-têtes de ligne, etc)_.<br/> D'autres stories d'exemples plus spécifiques sur des usages avancées du composant sont présentes dans le menu **"Exemples"**.`,

--- a/stories/dsfr/Tag.stories.svelte
+++ b/stories/dsfr/Tag.stories.svelte
@@ -13,9 +13,28 @@
   const { Story } = defineMeta({
     title: "Composants/dsfr/Tag",
     component: DsfrTag,
-    argTypes: tagArgTypes,
+    argTypes: {
+      ...tagArgTypes,
+      onselected: {
+        description: "Déclenché lorsque le tag est sélectionné.<br>" + "`detail: string`",
+        table: {
+          category: "Événements",
+          type: { summary: "CustomEvent<string>" },
+        },
+        control: false,
+      },
+      onunselected: {
+        description: "Déclenché lorsque le tag est désélectionné.<br>" + "`detail: string`",
+        table: {
+          category: "Événements",
+          type: { summary: "CustomEvent<string>" },
+        },
+        control: false,
+      },
+    },
     args: tagArgs,
     parameters: {
+      actions: { handles: ["selected", "unselected"] },
       docs: {
         source: {
           transform: webComponentSourceCode("dsfr-tag"),

--- a/stories/dsfr/TagsGroup.stories.svelte
+++ b/stories/dsfr/TagsGroup.stories.svelte
@@ -13,9 +13,28 @@
   const { Story } = defineMeta({
     title: "Composants/dsfr/TagsGroup",
     component: DsfrTagsGroup,
-    argTypes: tagsGroupArgTypes,
+    argTypes: {
+      ...tagsGroupArgTypes,
+      onselected: {
+        description: "Déclenché lorsqu'un tag est sélectionné.<br>" + "`detail: string`",
+        table: {
+          category: "Événements",
+          type: { summary: "CustomEvent<string>" },
+        },
+        control: false,
+      },
+      onunselected: {
+        description: "Déclenché lorsqu'un tag est désélectionné.<br>" + "`detail: string`",
+        table: {
+          category: "Événements",
+          type: { summary: "CustomEvent<string>" },
+        },
+        control: false,
+      },
+    },
     args: tagsGroupArgs,
     parameters: {
+      actions: { handles: ["selected", "unselected"] },
       docs: {
         source: {
           transform: webComponentSourceCode("dsfr-tags-group"),

--- a/stories/dsfr/Textarea.stories.svelte
+++ b/stories/dsfr/Textarea.stories.svelte
@@ -34,9 +34,19 @@
         },
         table: { category: "message" },
       },
+      onvaluechanged: {
+        description:
+          "Déclenché lors du changement de valeur du champ de saisie.<br>" + "`detail: string`",
+        table: {
+          category: "Événements",
+          type: { summary: "CustomEvent<string>" },
+        },
+        control: false,
+      },
     },
     args,
     parameters: {
+      actions: { handles: ["valuechanged"] },
       docs: {
         source: {
           transform: webComponentSourceCode("dsfr-textarea"),

--- a/stories/dsfr/Toggle.stories.svelte
+++ b/stories/dsfr/Toggle.stories.svelte
@@ -13,9 +13,21 @@
   const { Story } = defineMeta({
     title: "Composants/dsfr/Toggle",
     component: DsfrToggle,
-    argTypes: toggleArgTypes,
+    argTypes: {
+      ...toggleArgTypes,
+      onvaluechanged: {
+        description:
+          "Déclenché lors du changement d'état de l'interrupteur.<br>" + "`detail: boolean`",
+        table: {
+          category: "Événements",
+          type: { summary: "CustomEvent<boolean>" },
+        },
+        control: false,
+      },
+    },
     args: toggleArgs,
     parameters: {
+      actions: { handles: ["valuechanged"] },
       docs: {
         source: {
           transform: webComponentSourceCode("dsfr-toggle"),

--- a/stories/dsfr/User.stories.svelte
+++ b/stories/dsfr/User.stories.svelte
@@ -32,6 +32,24 @@
         control: false,
         table: { category: "Slots" },
       },
+      onlogout: {
+        description: "Déclenché lors du clic sur le bouton de déconnexion.",
+        table: {
+          category: "Événements",
+          type: { summary: "CustomEvent<void>" },
+        },
+        control: false,
+      },
+      onlinkclicked: {
+        description:
+          "Déclenché au clic sur un lien du menu utilisateur.<br>" +
+          "`detail: { link: UserLink, index: number }`",
+        table: {
+          category: "Événements",
+          type: { summary: "CustomEvent<{ link: UserLink, index: number }>" },
+        },
+        control: false,
+      },
     },
     args: {
       id: "user-menu",
@@ -47,6 +65,7 @@
       logoutLabel: "Se déconnecter",
     },
     parameters: {
+      actions: { handles: ["logout", "linkclicked"] },
       docs: {
         source: {
           transform: webComponentSourceCode("dsfr-user"),


### PR DESCRIPTION
## Décrire les changements

Cette story améliore la documentation des évènements des composants, en effectuant les évolutions suivantes : 
- Uniformisation de la façon de déclarer les évènements _(suppression de l'utilisation de `createEventDispatcher` au profit de `$host().dispatchEvent`)_
- Ajout des évènements dans la table des arguments des stories

## Autres informations

<!-- Ajoutez ici tout autre commentaire ou toute autre information concernant cette Pull Request. -->
