### PR TITLE
[STORYBOOK] Ajoute la déclaration du dossier statique pour Storybook

### DIFF
--- a/.storybook/anssi.theme.ts
+++ b/.storybook/anssi.theme.ts
@@ -4,6 +4,6 @@ export default create({
   base: "light",
   brandTitle: "UI Kit du Lab. ANSSI",
   brandUrl: "https://lab.cyber.gouv.fr/",
-  brandImage: "/static/ANSSI-ui-kit.svg",
+  brandImage: "./ANSSI-ui-kit.svg",
   brandTarget: "_self",
 });

--- a/.storybook/main.ts
+++ b/.storybook/main.ts
@@ -10,6 +10,7 @@ const __dirname = dirname(__filename);
 const varEnv = loadEnv(process.env.STORYBOOK_ENV ?? "production", process.cwd(), "VITE_");
 
 const config: StorybookConfig = {
+  staticDirs: ["../static"],
   stories: ["../stories/**/*.mdx", "../stories/**/*.stories.@(js|ts|svelte)"],
   addons: [
     "@storybook/addon-svelte-csf",

--- a/stories/composants/BandeauPage.stories.svelte
+++ b/stories/composants/BandeauPage.stories.svelte
@@ -23,7 +23,7 @@
       description:
         "Lorem ipsum dolor sit amet, consectetur adipiscing elit. Cras tincidunt felis in velit semper euismod.",
       inverse: false,
-      urlImage: "/static/images/hero-placeholder.jpg",
+      urlImage: "/images/hero-placeholder.jpg",
       sansImage: false,
       boutons: [
         {


### PR DESCRIPTION
## Décrire les changements

Certaines images utilisées dans Storybook (dont le logo ANSSI dans le Header Storybook) ne s'affichent.
Cela venait du fait que la déclaration du dossier où sont stocker les statiques, n'avait pas été ajouté à la configuration Storybook.

Cette PR corrige ce point, en ajoutant la déclaration du dossier statique pour Storybook.

## Autres informations

<!-- Ajoutez ici tout autre commentaire ou toute autre information concernant cette Pull Request. -->
