### PR TITLE
[COMPOSANT] DsfrAlert - Améliore le fonctionnement des props `hasTitle` et `hasDescription`

### DIFF
--- a/src/lib/dsfr/DsfrAlert.svelte
+++ b/src/lib/dsfr/DsfrAlert.svelte
@@ -55,16 +55,18 @@
 
   let displayAlert = $state(true);
   let iconClass = $derived(icon && setIconClass(icon));
-  let showTitle = $derived(hasTitle !== "false" && hasTitle !== false);
-  let showDescription = $derived(hasDescription !== "false" && hasDescription !== false);
+  let showTitle = $derived(size === "md" || (hasTitle !== "false" && hasTitle !== false));
+  let showDescription = $derived(
+    size === "sm" || (hasDescription !== "false" && hasDescription !== false),
+  );
 </script>
 
 {#if displayAlert}
   <div {id} class={["fr-alert", `fr-alert--${type}`, `fr-alert--${size}`, iconClass]}>
-    {#if showTitle || size === "md"}
+    {#if showTitle}
       <svelte:element this={titleTag} class="fr-alert__title">{title}</svelte:element>
     {/if}
-    {#if showDescription || size === "sm"}
+    {#if showDescription}
       <slot name="description">
         <p>{text}</p>
       </slot>

--- a/src/lib/dsfr/DsfrAlert.svelte
+++ b/src/lib/dsfr/DsfrAlert.svelte
@@ -12,6 +12,7 @@
       id: { attribute: "id", type: "String" },
       dismissible: { attribute: "dismissible", type: "Boolean" },
       icon: { attribute: "icon", type: "String" },
+      titleTag: { attribute: "title-tag", type: "String" },
     },
     extend: withIconsStyleSheet,
   }}
@@ -35,6 +36,7 @@
     id?: string;
     dismissible?: boolean;
     icon?: string;
+    titleTag?: "h1" | "h2" | "h3" | "h4" | "h5" | "h6" | "p";
   }
 
   let {
@@ -48,6 +50,7 @@
     icon,
     dismissible = false,
     buttonCloseLabel,
+    titleTag = "h3",
   }: Props = $props();
 
   let displayAlert = $state(true);
@@ -59,7 +62,7 @@
 {#if displayAlert}
   <div {id} class={["fr-alert", `fr-alert--${type}`, `fr-alert--${size}`, iconClass]}>
     {#if showTitle || size === "md"}
-      <h3 class="fr-alert__title">{title}</h3>
+      <svelte:element this={titleTag} class="fr-alert__title">{title}</svelte:element>
     {/if}
     {#if showDescription || size === "sm"}
       <slot name="description">

--- a/src/lib/dsfr/DsfrAlert.svelte
+++ b/src/lib/dsfr/DsfrAlert.svelte
@@ -3,9 +3,9 @@
     tag: "dsfr-alert",
     props: {
       buttonCloseLabel: { attribute: "button-close-label", type: "String" },
-      hasTitle: { attribute: "has-title", type: "Boolean" },
+      hasTitle: { attribute: "has-title", type: "String" },
       title: { attribute: "title", type: "String" },
-      hasDescription: { attribute: "has-description", type: "Boolean" },
+      hasDescription: { attribute: "has-description", type: "String" },
       text: { attribute: "text", type: "String" },
       type: { attribute: "type", type: "String" },
       size: { attribute: "size", type: "String" },
@@ -26,9 +26,9 @@
   type AlertSize = Extract<Size, "sm" | "md">;
   interface Props {
     buttonCloseLabel?: string;
-    hasTitle?: boolean;
+    hasTitle?: boolean | string;
     title?: string;
-    hasDescription?: boolean;
+    hasDescription?: boolean | string;
     text?: string;
     type?: "default" | "success" | "error" | "info" | "warning";
     size?: AlertSize;
@@ -52,14 +52,16 @@
 
   let displayAlert = $state(true);
   let iconClass = $derived(icon && setIconClass(icon));
+  let showTitle = $derived(hasTitle !== "false" && hasTitle !== false);
+  let showDescription = $derived(hasDescription !== "false" && hasDescription !== false);
 </script>
 
 {#if displayAlert}
   <div {id} class={["fr-alert", `fr-alert--${type}`, `fr-alert--${size}`, iconClass]}>
-    {#if hasTitle || size === "md"}
+    {#if showTitle || size === "md"}
       <h3 class="fr-alert__title">{title}</h3>
     {/if}
-    {#if hasDescription || size === "sm"}
+    {#if showDescription || size === "sm"}
       <slot name="description">
         <p>{text}</p>
       </slot>

--- a/stories/dsfr/Alert.stories.svelte
+++ b/stories/dsfr/Alert.stories.svelte
@@ -40,9 +40,9 @@
 {#snippet template(args: Args)}
   <dsfr-alert
     button-close-label={args.buttonCloseLabel}
-    has-title={args.hasTitle || undefined}
+    has-title={args.hasTitle}
     title={args.title}
-    has-description={args.hasDescription || undefined}
+    has-description={args.hasDescription}
     text={args.text}
     type={args.type}
     size={args.size}

--- a/stories/dsfr/Alert.stories.svelte
+++ b/stories/dsfr/Alert.stories.svelte
@@ -18,6 +18,11 @@
     args: alertArgs,
     argTypes: {
       ...alertArgTypes,
+      titleTag: {
+        control: { type: "select" },
+        description: "Balise HTML du titre",
+        options: ["h1", "h2", "h3", "h4", "h5", "h6", "p"],
+      },
       description: {
         description: "Contenu de la description (remplace la prop `text` avec du HTML riche)",
         control: false,
@@ -49,6 +54,7 @@
     id={args.id}
     dismissible={args.dismissible || undefined}
     icon={args.icon}
+    title-tag={args.titleTag}
   ></dsfr-alert>
 {/snippet}
 


### PR DESCRIPTION
## Décrire les changements

Cette PR améliore le composant `DsfrAlert` pour une meilleure compatibilité **Web Component** et un respect strict des règles DSFR.

Ainsi cette PR embarque les évolutions suivantes : 

1) Les props `hasTitle` et `hasDescription` étaient définies par défaut à `true`, ce qui les rendaient impossible à passer à `false` en Web Component. <br/><br/>Pour corriger ce problème sans causer un breaking change les attributs `has-title` et `has-description` sont désormais déclarés en type `String` côté Web Component. Des variables dérivées (`showTitle`, `showDescription`) se chargent de convertir la valeur reçue _(string ou booléen)_ en booléen exploitable par le template.

2) Par ailleurs, cette PR effectue l'ajout de la prop `titleTag` permettant de choisir la balise HTML du titre (`h1` à `h6` ou `p`). 
Par défaut la valeur de cette prop est `h3` comme dans [la documentation du DSFR](https://www.systeme-de-design.gouv.fr/version-courante/fr/composants/alerte/code-de-l-alerte#structure-du-composant).

3) Enfin, la PR améliore la logique d'affichage du titre et de la description en intégrant la contrainte DSFR directement dans les variables dérivées :
- Le titre est obligatoire mais optionnel en taille SM
- Le texte de description est optionnel, mais obligatoire en taille SM

## Autres informations

- https://www.systeme-de-design.gouv.fr/version-courante/fr/composants/alerte/demonstration-de-l-alerte
- https://www.systeme-de-design.gouv.fr/version-courante/fr/composants/alerte/design-de-l-alerte
- https://www.systeme-de-design.gouv.fr/version-courante/fr/composants/alerte/code-de-l-alerte#structure-du-composant
