### PR TITLE
[COMPOSANT] DsfrDropdown - Ajoute la prop `disabled` pour désactiver le bouton d'ouverture

### DIFF
--- a/src/lib/dsfr/DsfrDropdown.svelte
+++ b/src/lib/dsfr/DsfrDropdown.svelte
@@ -13,6 +13,7 @@
       contentType: { attribute: "content-type", type: "String" },
       align: { attribute: "align", type: "String" },
       items: { attribute: "items", type: "Array" },
+      disabled: { attribute: "disabled", type: "Boolean", reflect: true },
     },
     extend: withIconsStyleSheet,
   }}
@@ -63,6 +64,8 @@
     align?: "left" | "right";
     /** Items du menu */
     items?: ButtonItem[];
+    /** Désactive le bouton d'ouverture du dropdown */
+    disabled?: boolean;
   }
 
   let {
@@ -77,6 +80,7 @@
     contentType = "custom",
     align = "left",
     items = [],
+    disabled,
   }: Props = $props();
   let dropdown: HTMLElement;
   let effectiveAlign = $state<"left" | "right">(align);
@@ -253,6 +257,7 @@
         aria-expanded="false"
         aria-controls={collapseId}
         onclick={handleClick}
+        {disabled}
       />
     </slot>
     <div

--- a/stories/dsfr/Dropdown.stories.svelte
+++ b/stories/dsfr/Dropdown.stories.svelte
@@ -36,6 +36,10 @@
         },
         control: false,
       },
+      disabled: {
+        control: "boolean",
+        description: "Désactive le bouton d'ouverture du dropdown",
+      },
     },
     args: {
       id: "dropdown-id",
@@ -84,6 +88,7 @@
       content-type={args.contentType}
       align={args.align}
       items={args.items}
+      disabled={args.disabled || undefined}
     >
     </dsfr-dropdown>
   </div>


### PR DESCRIPTION
## Décrire les changements

Ajoute la prop `disabled` permettant de désactiver le bouton d'ouverture du composant.

## Autres informations

<!-- Ajoutez ici tout autre commentaire ou toute autre information concernant cette Pull Request. -->
