### PR TITLE
[COMPOSANT] DSFR - Ajoute le composant `DsfrLabel`

### DIFF
--- a/src/lib/dsfr/DsfrInput.svelte
+++ b/src/lib/dsfr/DsfrInput.svelte
@@ -28,6 +28,8 @@
       icon: { attribute: "icon", type: "String" },
       addon: { attribute: "addon", type: "Boolean" },
       action: { attribute: "action", type: "Boolean" },
+      labelSize: { attribute: "label-size", type: "String" },
+      labelWeight: { attribute: "label-weight", type: "String" },
     },
     extend: (CustomElementClass) => {
       return class extends CustomElementClass {
@@ -54,6 +56,7 @@
 />
 
 <script lang="ts">
+  import type { TextSize, TextWeight } from "$lib/types";
   import { getIconsStyleSheet, setIconClass, setThemeable } from "$lib/utilitaires";
   import { createFormValidation } from "$lib/utilitaires/createFormValidation.svelte";
 
@@ -120,6 +123,10 @@
     internals?: ElementInternals;
     /** Callback appelé lors du changement de valeur du champ de saisie */
     onvaluechanged?: (value: string) => void;
+    /** Applique une classe utilitaire de taille de texte DSFR (fr-text--xs à fr-text--xl, fr-text--lead) sur le label */
+    labelSize?: TextSize;
+    /** Applique une classe utilitaire de graisse DSFR (fr-text--light à fr-text--heavy) sur le label */
+    labelWeight?: TextWeight;
   }
 
   let {
@@ -151,6 +158,8 @@
     step,
     internals,
     onvaluechanged,
+    labelSize,
+    labelWeight,
   }: Props = $props();
 
   let formControlElement: HTMLInputElement;
@@ -242,6 +251,8 @@
     {status}
     {disabled}
     hidden={hideLabel || isLabelEmpty}
+    {labelSize}
+    {labelWeight}
   />
   {#snippet inputField()}
     <input

--- a/src/lib/dsfr/DsfrInput.svelte
+++ b/src/lib/dsfr/DsfrInput.svelte
@@ -56,6 +56,8 @@
 <script lang="ts">
   import { getIconsStyleSheet, setIconClass, setThemeable } from "$lib/utilitaires";
   import { createFormValidation } from "$lib/utilitaires/createFormValidation.svelte";
+
+  import DsfrLabel from "$lib/dsfr/DsfrLabel.svelte";
   import DsfrMessagesGroup from "./DsfrMessagesGroup.svelte";
 
   let host = $host();
@@ -232,13 +234,15 @@
 </script>
 
 <div class={["fr-input-group", disabledClass, statusClass]}>
-  <label class="fr-label" class:fr-sr-only={hideLabel || isLabelEmpty} for={id}>
+  <DsfrLabel
+    for={id}
     {label}
-
-    {#if hint}
-      <span class="fr-hint-text">{hint}</span>
-    {/if}
-  </label>
+    {hint}
+    context="field"
+    {status}
+    {disabled}
+    hidden={hideLabel || isLabelEmpty}
+  />
   {#snippet inputField()}
     <input
       bind:this={formControlElement}
@@ -307,18 +311,10 @@
   @import "@gouvfr/dsfr/dist/component/input/input.main.css";
 
   @include set-shadow-host();
-  @include set-dsfr-sizing("input-group") {
-    &:has(.fr-sr-only) .fr-input {
-      margin-top: 0;
-    }
-  }
+  @include set-dsfr-sizing("input-group");
 
   .fr-input-group:not(:last-child) {
     margin-bottom: 0;
-  }
-
-  .fr-sr-only {
-    @include visually-hidden();
   }
 
   .fr-input-wrap--addon {

--- a/src/lib/dsfr/DsfrLabel.svelte
+++ b/src/lib/dsfr/DsfrLabel.svelte
@@ -1,0 +1,127 @@
+<svelte:options
+  customElement={{
+    tag: "dsfr-label",
+    props: {
+      for: { attribute: "for", type: "String" },
+      label: { attribute: "label", type: "String" },
+      hint: { attribute: "hint", type: "String" },
+      hidden: { attribute: "hidden", type: "Boolean" },
+      id: { attribute: "id", type: "String" },
+      class: { attribute: "class", type: "String" },
+      context: { attribute: "context", type: "String" },
+      inline: { attribute: "inline", type: "Boolean" },
+      status: { attribute: "status", type: "String" },
+      disabled: { attribute: "disabled", type: "Boolean" },
+    },
+  }}
+/>
+
+<script lang="ts">
+  interface Props {
+    /** Attribut for du label (id du champ associé) */
+    for: string;
+    /** Texte du label */
+    label?: string;
+    /** Texte additionnel sous le label */
+    hint?: string;
+    /** Masque visuellement le label tout en le gardant accessible */
+    hidden?: boolean;
+    /** Attribut id du label */
+    id?: string;
+    /** Classe(s) additionnelle(s) */
+    class?: string;
+    /**
+     * Contexte d'affichage du composant.
+     * - "field" : inside input-group ou select-group → fr-hint-text reçoit une marge supérieure
+     * - "default" (défaut) : checkbox, radio, segmented… → pas de marge spécifique
+     */
+    context?: "field" | "default";
+    /** Gère les états du label lorsque celui-ci est aligné horizontalement avec le champ */
+    inline?: boolean;
+    /**
+     * Statut du champ associé, applique la couleur correspondante sur le label.
+     * - "error" → fr-label--error
+     * - "valid" → fr-label--success
+     * - "info"  → fr-label--info
+     */
+    status?: "default" | "valid" | "error" | "info";
+    /** Désactive le label (applique la couleur désactivée) */
+    disabled?: boolean;
+  }
+
+  const {
+    for: forAttr,
+    label,
+    hint,
+    hidden = false,
+    id,
+    class: extraClass,
+    context = "default",
+    inline = false,
+    status = "default",
+    disabled = false,
+  }: Props = $props();
+</script>
+
+<label
+  class={[
+    "fr-label",
+    extraClass,
+    {
+      "fr-sr-only": hidden,
+      "fr-label--field": context === "field",
+      "fr-label--inline": inline,
+      "fr-label--error": status === "error",
+      "fr-label--success": status === "valid",
+      "fr-label--info": status === "info",
+      "fr-label--disabled": disabled,
+    },
+  ]}
+  for={forAttr}
+  {id}
+>
+  <slot>{label}</slot>
+
+  {#if hint || $$slots.hint}
+    <span class="fr-hint-text">
+      <slot name="hint">
+        {hint}
+      </slot>
+    </span>
+  {/if}
+</label>
+
+<style lang="scss">
+  @use "src/lib/styles/mixins-dsfr.scss" as *;
+  // DSFR Core styles
+  @import "@gouvfr/dsfr/src/dsfr/core/index";
+  @import "@gouvfr/dsfr/src/dsfr/core/style/action/module/disabled";
+  @import "@gouvfr/dsfr/src/dsfr/core/style/reset/module/tap-highlight";
+  // DSFR Component styles
+  @import "@gouvfr/dsfr/src/dsfr/component/form/style/module/hint-text";
+  @import "@gouvfr/dsfr/src/dsfr/component/form/style/module/label";
+  @import "@gouvfr/dsfr/src/dsfr/component/form/style/scheme";
+  @include _form-scheme();
+
+  @include set-shadow-host();
+  @include set-dsfr-sizing("label") {
+    &--field {
+      margin-bottom: 0.5rem;
+
+      .fr-hint-text {
+        margin-top: 0.25rem;
+      }
+    }
+
+    &--inline {
+      .fr-hint-text {
+        margin: 0;
+        width: 100%;
+      }
+    }
+  }
+
+  .fr-sr-only {
+    @include sr-only();
+  }
+</style>

--- a/src/lib/dsfr/DsfrLabel.svelte
+++ b/src/lib/dsfr/DsfrLabel.svelte
@@ -12,11 +12,15 @@
       inline: { attribute: "inline", type: "Boolean" },
       status: { attribute: "status", type: "String" },
       disabled: { attribute: "disabled", type: "Boolean" },
+      labelSize: { attribute: "label-size", type: "String" },
+      labelWeight: { attribute: "label-weight", type: "String" },
     },
   }}
 />
 
 <script lang="ts">
+  import type { TextSize, TextWeight } from "$lib/types";
+
   interface Props {
     /** Attribut for du label (id du champ associé) */
     for: string;
@@ -47,6 +51,10 @@
     status?: "default" | "valid" | "error" | "info";
     /** Désactive le label (applique la couleur désactivée) */
     disabled?: boolean;
+    /** Applique une classe utilitaire de taille de texte DSFR (fr-text--xs à fr-text--xl, fr-text--lead) */
+    labelSize?: TextSize;
+    /** Applique une classe utilitaire de graisse DSFR (fr-text--light à fr-text--heavy) */
+    labelWeight?: TextWeight;
   }
 
   const {
@@ -60,6 +68,8 @@
     inline = false,
     status = "default",
     disabled = false,
+    labelSize,
+    labelWeight,
   }: Props = $props();
 </script>
 
@@ -80,8 +90,9 @@
   for={forAttr}
   {id}
 >
-  <slot>{label}</slot>
-
+  <span class={[labelSize && `fr-text--${labelSize}`, labelWeight && `fr-text--${labelWeight}`]}>
+    <slot>{label}</slot>
+  </span>
   {#if hint || $$slots.hint}
     <span class="fr-hint-text">
       <slot name="hint">
@@ -97,6 +108,8 @@
   @import "@gouvfr/dsfr/src/dsfr/core/index";
   @import "@gouvfr/dsfr/src/dsfr/core/style/action/module/disabled";
   @import "@gouvfr/dsfr/src/dsfr/core/style/reset/module/tap-highlight";
+  @import "@gouvfr/dsfr/src/dsfr/core/style/typography/module/typography";
+  @import "@gouvfr/dsfr/src/dsfr/core/style/typography/module/font-weight";
   // DSFR Component styles
   @import "@gouvfr/dsfr/src/dsfr/component/form/style/module/hint-text";
   @import "@gouvfr/dsfr/src/dsfr/component/form/style/module/label";
@@ -105,6 +118,8 @@
 
   @include set-shadow-host();
   @include set-dsfr-sizing("label") {
+    --text-spacing: 0;
+
     &--field {
       margin-bottom: 0.5rem;
 

--- a/src/lib/dsfr/DsfrRange.svelte
+++ b/src/lib/dsfr/DsfrRange.svelte
@@ -33,6 +33,8 @@
   import type { Size, Status } from "$lib/types";
   import { setThemeable } from "$lib/utilitaires";
 
+  import DsfrLabel from "$lib/dsfr/DsfrLabel.svelte";
+
   setThemeable($host());
 
   type RangeSize = Extract<Size, "sm" | "md">;
@@ -226,14 +228,15 @@
   ]}
   id="{id}-group"
 >
-  <label class="fr-label" class:fr-sr-only={hideLabel || isLabelEmpty} id="{id}-label" for={id}>
+  <DsfrLabel
+    for={id}
     {label}
-    {#if hint}
-      <span class="fr-hint-text">
-        {hint}
-      </span>
-    {/if}
-  </label>
+    {hint}
+    id="{id}-label"
+    {status}
+    {disabled}
+    hidden={hideLabel || isLabelEmpty}
+  />
 
   <div
     bind:this={rangeEl}
@@ -321,9 +324,5 @@
         visibility: hidden;
       }
     }
-  }
-
-  .fr-sr-only {
-    @include visually-hidden();
   }
 </style>

--- a/src/lib/dsfr/DsfrRange.svelte
+++ b/src/lib/dsfr/DsfrRange.svelte
@@ -24,13 +24,15 @@
       status: { attribute: "status", type: "String" },
       errorMessage: { attribute: "error-message", type: "String" },
       hideOutputLabel: { attribute: "hide-output-label", type: "Boolean" },
+      labelSize: { attribute: "label-size", type: "String" },
+      labelWeight: { attribute: "label-weight", type: "String" },
     },
   }}
 />
 
 <script lang="ts">
   import { untrack } from "svelte";
-  import type { Size, Status } from "$lib/types";
+  import type { Size, Status, TextSize, TextWeight } from "$lib/types";
   import { setThemeable } from "$lib/utilitaires";
 
   import DsfrLabel from "$lib/dsfr/DsfrLabel.svelte";
@@ -89,6 +91,10 @@
     onvaluechanged?: (value: number) => void;
     /** Callback appelé lors du changement de la seconde valeur (curseur double) */
     onvalue2changed?: (value: number) => void;
+    /** Applique une classe utilitaire de taille de texte DSFR (fr-text--xs à fr-text--xl, fr-text--lead) sur le label */
+    labelSize?: TextSize;
+    /** Applique une classe utilitaire de graisse DSFR (fr-text--light à fr-text--heavy) sur le label */
+    labelWeight?: TextWeight;
   }
 
   let {
@@ -116,6 +122,8 @@
     hideOutputLabel = false,
     onvaluechanged,
     onvalue2changed,
+    labelSize,
+    labelWeight,
   }: Props = $props();
 
   const decorate = (val: number | string) => `${prefix ?? ""}${val}${suffix ?? ""}`;
@@ -236,6 +244,8 @@
     {status}
     {disabled}
     hidden={hideLabel || isLabelEmpty}
+    {labelSize}
+    {labelWeight}
   />
 
   <div

--- a/src/lib/dsfr/DsfrSearch.svelte
+++ b/src/lib/dsfr/DsfrSearch.svelte
@@ -18,6 +18,8 @@
       pattern: { attribute: "pattern", type: "String" },
       readonly: { attribute: "readonly", type: "Boolean" },
       required: { attribute: "required", type: "Boolean" },
+      labelSize: { attribute: "label-size", type: "String" },
+      labelWeight: { attribute: "label-weight", type: "String" },
     },
     extend: (customElementConstructor) => {
       return class extends customElementConstructor {
@@ -33,7 +35,7 @@
 />
 
 <script lang="ts">
-  import type { Size } from "$lib/types";
+  import type { Size, TextSize, TextWeight } from "$lib/types";
   import { setThemeable } from "$lib/utilitaires";
   import { createFormValidation } from "$lib/utilitaires/createFormValidation.svelte";
 
@@ -81,6 +83,10 @@
     onvaluechanged?: (value: string) => void;
     /** Callback appelé lors de la soumission de la recherche */
     onsearch?: (value: string) => void;
+    /** Applique une classe utilitaire de taille de texte DSFR (fr-text--xs à fr-text--xl, fr-text--lead) sur le label */
+    labelSize?: TextSize;
+    /** Applique une classe utilitaire de graisse DSFR (fr-text--light à fr-text--heavy) sur le label */
+    labelWeight?: TextWeight;
   }
 
   let {
@@ -103,6 +109,8 @@
     internals,
     onvaluechanged,
     onsearch,
+    labelSize,
+    labelWeight,
   }: Props = $props();
 
   let formControlElement: HTMLInputElement;
@@ -179,7 +187,7 @@
 </script>
 
 <div class={["fr-search-bar", sizeClass]} role="search">
-  <DsfrLabel for={inputId} label={inputLabel} hidden />
+  <DsfrLabel for={inputId} label={inputLabel} hidden {labelSize} {labelWeight} />
   <input
     bind:this={formControlElement}
     type="search"

--- a/src/lib/dsfr/DsfrSearch.svelte
+++ b/src/lib/dsfr/DsfrSearch.svelte
@@ -36,6 +36,9 @@
   import type { Size } from "$lib/types";
   import { setThemeable } from "$lib/utilitaires";
   import { createFormValidation } from "$lib/utilitaires/createFormValidation.svelte";
+
+  import DsfrLabel from "$lib/dsfr/DsfrLabel.svelte";
+
   setThemeable($host());
 
   type SearchSize = Extract<Size, "md" | "lg">;
@@ -176,9 +179,7 @@
 </script>
 
 <div class={["fr-search-bar", sizeClass]} role="search">
-  {#if inputLabel}
-    <label class="fr-label" for={inputId}> {inputLabel} </label>
-  {/if}
+  <DsfrLabel for={inputId} label={inputLabel} hidden />
   <input
     bind:this={formControlElement}
     type="search"

--- a/src/lib/dsfr/DsfrSelect.svelte
+++ b/src/lib/dsfr/DsfrSelect.svelte
@@ -37,6 +37,8 @@
 <script lang="ts">
   import { setThemeable } from "$lib/utilitaires";
   import { createFormValidation } from "$lib/utilitaires/createFormValidation.svelte";
+
+  import DsfrLabel from "$lib/dsfr/DsfrLabel.svelte";
   import DsfrMessagesGroup from "./DsfrMessagesGroup.svelte";
 
   setThemeable($host());
@@ -190,13 +192,7 @@
 </script>
 
 <div class={["fr-select-group", statusClass, disabledClass]}>
-  <label class="fr-label" class:fr-sr-only={hideLabel} for={id}>
-    {label}
-
-    {#if hint}
-      <span class="fr-hint-text">{hint}</span>
-    {/if}
-  </label>
+  <DsfrLabel for={id} {label} {hint} hidden={hideLabel} context="field" {status} {disabled} />
   <select
     bind:this={formControlElement}
     class="fr-select"
@@ -255,17 +251,9 @@
   @import "@gouvfr/dsfr/dist/component/select/select.main.css";
 
   @include set-shadow-host($tag: "dsfr-select");
-  @include set-dsfr-sizing("select-group") {
-    &:has(.fr-sr-only) .fr-select {
-      margin-top: 0;
-    }
-  }
+  @include set-dsfr-sizing("select-group");
 
   .fr-select-group:not(:last-child) {
     margin-bottom: 0;
-  }
-
-  .fr-sr-only {
-    @include visually-hidden();
   }
 </style>

--- a/src/lib/dsfr/DsfrSelect.svelte
+++ b/src/lib/dsfr/DsfrSelect.svelte
@@ -20,6 +20,8 @@
       form: { attribute: "form", type: "String", reflect: true },
       required: { attribute: "required", type: "Boolean" },
       name: { attribute: "name", type: "String", reflect: true },
+      labelSize: { attribute: "label-size", type: "String" },
+      labelWeight: { attribute: "label-weight", type: "String" },
     },
     extend: (customElementConstructor) => {
       return class extends customElementConstructor {
@@ -35,6 +37,7 @@
 />
 
 <script lang="ts">
+  import type { TextSize, TextWeight } from "$lib/types";
   import { setThemeable } from "$lib/utilitaires";
   import { createFormValidation } from "$lib/utilitaires/createFormValidation.svelte";
 
@@ -92,6 +95,10 @@
     internals?: ElementInternals;
     /** Attribut name du champs de saisie */
     name?: string;
+    /** Applique une classe utilitaire de taille de texte DSFR (fr-text--xs à fr-text--xl, fr-text--lead) sur le label */
+    labelSize?: TextSize;
+    /** Applique une classe utilitaire de graisse DSFR (fr-text--light à fr-text--heavy) sur le label */
+    labelWeight?: TextWeight;
   }
 
   let {
@@ -114,6 +121,8 @@
     onvaluechanged,
     internals,
     name,
+    labelSize,
+    labelWeight,
   }: Props = $props();
 
   let formControlElement: HTMLSelectElement;
@@ -192,7 +201,17 @@
 </script>
 
 <div class={["fr-select-group", statusClass, disabledClass]}>
-  <DsfrLabel for={id} {label} {hint} hidden={hideLabel} context="field" {status} {disabled} />
+  <DsfrLabel
+    for={id}
+    {label}
+    {hint}
+    hidden={hideLabel}
+    context="field"
+    {status}
+    {disabled}
+    {labelSize}
+    {labelWeight}
+  />
   <select
     bind:this={formControlElement}
     class="fr-select"

--- a/src/lib/dsfr/DsfrTextarea.svelte
+++ b/src/lib/dsfr/DsfrTextarea.svelte
@@ -21,6 +21,8 @@
       minlength: { attribute: "minlength", type: "Number" },
       readonly: { attribute: "readonly", type: "Boolean" },
       required: { attribute: "required", type: "Boolean" },
+      labelSize: { attribute: "label-size", type: "String" },
+      labelWeight: { attribute: "label-weight", type: "String" },
     },
     extend: (customElementConstructor) => {
       return class extends customElementConstructor {
@@ -37,6 +39,7 @@
 
 <script lang="ts">
   import type { HTMLTextareaAttributes } from "svelte/elements";
+  import type { TextSize, TextWeight } from "$lib/types";
   import { setThemeable } from "$lib/utilitaires";
   import { createFormValidation } from "$lib/utilitaires/createFormValidation.svelte";
 
@@ -88,6 +91,10 @@
     internals?: ElementInternals;
     /** Callback appelé lors du changement de valeur du champ de saisie */
     onvaluechanged?: (value: string) => void;
+    /** Applique une classe utilitaire de taille de texte DSFR (fr-text--xs à fr-text--xl, fr-text--lead) sur le label */
+    labelSize?: TextSize;
+    /** Applique une classe utilitaire de graisse DSFR (fr-text--light à fr-text--heavy) sur le label */
+    labelWeight?: TextWeight;
   }
 
   let {
@@ -112,6 +119,8 @@
     required,
     internals,
     onvaluechanged,
+    labelSize,
+    labelWeight,
   }: Props = $props();
 
   let formControlElement: HTMLTextAreaElement;
@@ -199,6 +208,8 @@
     {status}
     {disabled}
     hidden={hideLabel || isLabelEmpty}
+    {labelSize}
+    {labelWeight}
   />
   <textarea
     bind:this={formControlElement}

--- a/src/lib/dsfr/DsfrTextarea.svelte
+++ b/src/lib/dsfr/DsfrTextarea.svelte
@@ -39,6 +39,8 @@
   import type { HTMLTextareaAttributes } from "svelte/elements";
   import { setThemeable } from "$lib/utilitaires";
   import { createFormValidation } from "$lib/utilitaires/createFormValidation.svelte";
+
+  import DsfrLabel from "$lib/dsfr/DsfrLabel.svelte";
   import DsfrMessagesGroup from "./DsfrMessagesGroup.svelte";
 
   setThemeable($host());
@@ -189,13 +191,15 @@
   class={["fr-input-group", statusClass, { "fr-input-group--disabled": disabled }]}
   id={`input-group-${id}`}
 >
-  <label class="fr-label" class:fr-sr-only={hideLabel || isLabelEmpty} for={id}>
+  <DsfrLabel
+    for={id}
     {label}
-
-    {#if hint}
-      <span class="fr-hint-text">{hint}</span>
-    {/if}
-  </label>
+    {hint}
+    context="field"
+    {status}
+    {disabled}
+    hidden={hideLabel || isLabelEmpty}
+  />
   <textarea
     bind:this={formControlElement}
     {id}
@@ -241,13 +245,5 @@
   @import "@gouvfr/dsfr/dist/component/input/input.main.css";
 
   @include set-shadow-host();
-  @include set-dsfr-sizing("input-group") {
-    &:has(.fr-sr-only) .fr-input {
-      margin-top: 0;
-    }
-  }
-
-  .fr-sr-only {
-    @include visually-hidden();
-  }
+  @include set-dsfr-sizing("input-group");
 </style>

--- a/src/lib/index.ts
+++ b/src/lib/index.ts
@@ -47,6 +47,7 @@ export { default as DsfrFooter } from "./dsfr/DsfrFooter.svelte";
 export { default as DsfrHeader } from "./dsfr/DsfrHeader.svelte";
 export { default as DsfrHighlight } from "./dsfr/DsfrHighlight.svelte";
 export { default as DsfrInput } from "./dsfr/DsfrInput.svelte";
+export { default as DsfrLabel } from "./dsfr/DsfrLabel.svelte";
 export { default as DsfrLink } from "./dsfr/DsfrLink.svelte";
 export { default as DsfrLogo } from "./dsfr/DsfrLogo.svelte";
 export { default as DsfrMessagesGroup } from "./dsfr/DsfrMessagesGroup.svelte";

--- a/src/lib/types/global.ts
+++ b/src/lib/types/global.ts
@@ -29,6 +29,8 @@ export type Accent =
 export type iconPlace = "only" | "left" | "right";
 export type Size = "sm" | "md" | "lg" | "xl";
 export type Status = "success" | "warning" | "error" | "info" | "new";
+export type TextSize = "xs" | "sm" | "md" | "lg" | "xl" | "lead";
+export type TextWeight = "light" | "regular" | "bold" | "heavy";
 export type Target = "self" | "blank";
 
 export type Image = {

--- a/stories/dsfr/Input.stories.svelte
+++ b/stories/dsfr/Input.stories.svelte
@@ -33,6 +33,18 @@
         },
         table: { category: "message" },
       },
+      labelSize: {
+        control: "select",
+        options: [undefined, "xs", "sm", "md", "lg", "xl", "lead"],
+        description:
+          "Applique une classe utilitaire de taille de texte DSFR (fr-text--xs à fr-text--xl, fr-text--lead) sur le label",
+      },
+      labelWeight: {
+        control: "select",
+        options: [undefined, "light", "regular", "bold", "heavy"],
+        description:
+          "Applique une classe utilitaire de graisse DSFR (fr-text--light à fr-text--heavy) sur le label",
+      },
       onvaluechanged: {
         description:
           "Déclenché lors du changement de valeur du champ de saisie.<br>" + "`detail: string`",
@@ -84,6 +96,8 @@
     readonly={args.readonly || undefined}
     required={args.required || undefined}
     step={args.step}
+    label-size={args.labelSize}
+    label-weight={args.labelWeight}
   ></dsfr-input>
 {/snippet}
 

--- a/stories/dsfr/Label.stories.svelte
+++ b/stories/dsfr/Label.stories.svelte
@@ -1,0 +1,57 @@
+<script module lang="ts">
+  import { defineMeta } from "@storybook/addon-svelte-csf";
+  import { type ComponentProps } from "svelte";
+
+  import DsfrLabel from "$lib/dsfr/DsfrLabel.svelte";
+
+  const { Story } = defineMeta({
+    title: "Composants/dsfr/Label",
+    component: DsfrLabel,
+    argTypes: {
+      for: {
+        control: "text",
+        description: "Attribut for du label (id du champ associé)",
+      },
+      label: {
+        control: "text",
+        description: "Texte du label",
+      },
+      hint: {
+        control: "text",
+        description: "Texte additionnel sous le label",
+      },
+      hidden: {
+        control: "boolean",
+        description: "Masque visuellement le label tout en le gardant accessible (fr-sr-only)",
+      },
+      id: {
+        control: "text",
+        description: "Attribut id du label",
+      },
+    },
+    args: {
+      for: "champ-exemple",
+      label: "Libellé du champ",
+      hidden: false,
+    },
+    render: template,
+  });
+
+  type Args = ComponentProps<DsfrLabel>;
+</script>
+
+{#snippet template(args: Args)}
+  <dsfr-label
+    for={args.for}
+    label={args.label}
+    hint={args.hint}
+    hidden={args.hidden || undefined}
+    id={args.id}
+  ></dsfr-label>
+{/snippet}
+
+<Story name="Défaut" />
+
+<Story name="Avec texte additionnel" args={{ hint: "Format attendu : JJ/MM/AAAA." }} />
+
+<Story name="Masqué (fr-sr-only)" args={{ hidden: true }} />

--- a/stories/dsfr/Label.stories.svelte
+++ b/stories/dsfr/Label.stories.svelte
@@ -28,6 +28,18 @@
         control: "text",
         description: "Attribut id du label",
       },
+      labelSize: {
+        control: "select",
+        options: [undefined, "xs", "sm", "md", "lg", "xl", "lead"],
+        description:
+          "Applique une classe utilitaire de taille de texte DSFR (fr-text--xs à fr-text--xl, fr-text--lead)",
+      },
+      labelWeight: {
+        control: "select",
+        options: [undefined, "light", "regular", "bold", "heavy"],
+        description:
+          "Applique une classe utilitaire de graisse DSFR (fr-text--light à fr-text--heavy)",
+      },
     },
     args: {
       for: "champ-exemple",
@@ -47,6 +59,8 @@
     hint={args.hint}
     hidden={args.hidden || undefined}
     id={args.id}
+    label-size={args.labelSize}
+    label-weight={args.labelWeight}
   ></dsfr-label>
 {/snippet}
 
@@ -55,3 +69,27 @@
 <Story name="Avec texte additionnel" args={{ hint: "Format attendu : JJ/MM/AAAA." }} />
 
 <Story name="Masqué (fr-sr-only)" args={{ hidden: true }} />
+
+<Story name="Tailles de texte (fr-text--xs à fr-text--lead)">
+  {#snippet template(args: Args)}
+    <div style="display: flex; flex-direction: column; gap: 1rem;">
+      {#each ["xs", "sm", "md", "lg", "xl", "lead"] as size}
+        <dsfr-label for={args.for} label={"Label en fr-text--" + size} label-size={size}
+        ></dsfr-label>
+      {/each}
+    </div>
+  {/snippet}
+</Story>
+
+<Story name="Graisses de texte (fr-text--light à fr-text--heavy)">
+  {#snippet template(args: Args)}
+    <div style="display: flex; flex-direction: column; gap: 1rem;">
+      {#each ["light", "regular", "bold", "heavy"] as weight}
+        <dsfr-label for={args.for} label={"Label en fr-text--" + weight} label-weight={weight}
+        ></dsfr-label>
+      {/each}
+    </div>
+  {/snippet}
+</Story>
+
+<Story name="Taille et graisse combinées" args={{ labelSize: "lg", labelWeight: "bold" }} />

--- a/stories/dsfr/Range.stories.svelte
+++ b/stories/dsfr/Range.stories.svelte
@@ -20,6 +20,18 @@
         control: false,
         table: { category: "Slots" },
       },
+      labelSize: {
+        control: "select",
+        options: [undefined, "xs", "sm", "md", "lg", "xl", "lead"],
+        description:
+          "Applique une classe utilitaire de taille de texte DSFR (fr-text--xs à fr-text--xl, fr-text--lead) sur le label",
+      },
+      labelWeight: {
+        control: "select",
+        options: [undefined, "light", "regular", "bold", "heavy"],
+        description:
+          "Applique une classe utilitaire de graisse DSFR (fr-text--light à fr-text--heavy) sur le label",
+      },
       onvaluechanged: {
         description:
           "Déclenché lors du changement de la valeur principale.<br>" + "`detail: number`",
@@ -79,6 +91,8 @@
     status={args.status}
     error-message={args.errorMessage}
     hide-output-label={args.hideOutputLabel || undefined}
+    label-size={args.labelSize}
+    label-weight={args.labelWeight}
   ></dsfr-range>
 {/snippet}
 

--- a/stories/dsfr/Search.stories.svelte
+++ b/stories/dsfr/Search.stories.svelte
@@ -24,6 +24,18 @@
         },
         control: false,
       },
+      labelSize: {
+        control: "select",
+        options: [undefined, "xs", "sm", "md", "lg", "xl", "lead"],
+        description:
+          "Applique une classe utilitaire de taille de texte DSFR (fr-text--xs à fr-text--xl, fr-text--lead) sur le label",
+      },
+      labelWeight: {
+        control: "select",
+        options: [undefined, "light", "regular", "bold", "heavy"],
+        description:
+          "Applique une classe utilitaire de graisse DSFR (fr-text--light à fr-text--heavy) sur le label",
+      },
       onsearch: {
         description: "Déclenché lors de la soumission de la recherche.<br>" + "`detail: string`",
         table: {
@@ -65,6 +77,8 @@
     pattern={args.pattern}
     readonly={args.readonly || undefined}
     required={args.required || undefined}
+    label-size={args.labelSize}
+    label-weight={args.labelWeight}
   ></dsfr-search>
 {/snippet}
 

--- a/stories/dsfr/Select.stories.svelte
+++ b/stories/dsfr/Select.stories.svelte
@@ -38,6 +38,18 @@
         control: false,
         table: { category: "Slots" },
       },
+      labelSize: {
+        control: "select",
+        options: [undefined, "xs", "sm", "md", "lg", "xl", "lead"],
+        description:
+          "Applique une classe utilitaire de taille de texte DSFR (fr-text--xs à fr-text--xl, fr-text--lead) sur le label",
+      },
+      labelWeight: {
+        control: "select",
+        options: [undefined, "light", "regular", "bold", "heavy"],
+        description:
+          "Applique une classe utilitaire de graisse DSFR (fr-text--light à fr-text--heavy) sur le label",
+      },
       onvaluechanged: {
         description:
           "Déclenché lors du changement de valeur de la liste déroulante.<br>" + "`detail: string`",
@@ -81,6 +93,8 @@
     info-message={args.infoMessage}
     form={args.form}
     required={args.required || undefined}
+    label-size={args.labelSize}
+    label-weight={args.labelWeight}
   ></dsfr-select>
 {/snippet}
 

--- a/stories/dsfr/Textarea.stories.svelte
+++ b/stories/dsfr/Textarea.stories.svelte
@@ -34,6 +34,18 @@
         },
         table: { category: "message" },
       },
+      labelSize: {
+        control: "select",
+        options: [undefined, "xs", "sm", "md", "lg", "xl", "lead"],
+        description:
+          "Applique une classe utilitaire de taille de texte DSFR (fr-text--xs à fr-text--xl, fr-text--lead) sur le label",
+      },
+      labelWeight: {
+        control: "select",
+        options: [undefined, "light", "regular", "bold", "heavy"],
+        description:
+          "Applique une classe utilitaire de graisse DSFR (fr-text--light à fr-text--heavy) sur le label",
+      },
       onvaluechanged: {
         description:
           "Déclenché lors du changement de valeur du champ de saisie.<br>" + "`detail: string`",
@@ -75,6 +87,8 @@
     valid-message={args.validMessage}
     rows={args.rows}
     info-message={args.infoMessage}
+    label-size={args.labelSize}
+    label-weight={args.labelWeight}
   ></dsfr-textarea>
 {/snippet}
 


### PR DESCRIPTION
## Décrire les changements

Cette PR ajoute le composant `DsfrLabel` afin de mutualiser l'usage de la balise `<label class="fr-label"></label>` ainsi que les styles associées dans le maximum de composants où elle est présente.

Certains composants comme les composants `DsfrCheckbox`, `DsfrCheckboxesGroup`, `DsfrRadio`, `DsfrRadiosGroup`, `DsfrToggle` ne sont pas impactés par cette évolution en raison du fait que des styles associés à la balise `<label>` sont définis par les feuilles de styles dédiées à ces composants.

## Autres informations

<!-- Ajoutez ici tout autre commentaire ou toute autre information concernant cette Pull Request. -->
