### PR TITLE
[LAB] - LabAnssiBandeauPage - Ajoute les propriétés `theme` & `type`

### DIFF
--- a/src/lib/composants/BandeauPage.svelte
+++ b/src/lib/composants/BandeauPage.svelte
@@ -5,13 +5,14 @@
       titre: { attribute: "titre", type: "String" },
       baliseTitre: { attribute: "balise-titre", type: "String" },
       description: { attribute: "description", type: "String" },
-      actions: { attribute: "actions", type: "Object" },
       mention: { attribute: "mention", type: "String" },
-      inverse: { attribute: "inverse", type: "Boolean" },
       urlImage: { attribute: "url-image", type: "String" },
       sansImage: { attribute: "sans-image", type: "Boolean" },
       avecFilAriane: { attribute: "avec-fil-ariane", type: "Boolean" },
       liensFilAriane: { attribute: "liens-fil-ariane", type: "Array" },
+      type: { attribute: "type", type: "String" },
+      theme: { attribute: "theme", type: "String" },
+      inverse: { attribute: "inverse", type: "Boolean" },
       simple: { attribute: "simple", type: "Boolean" },
       ficheCatalogue: { attribute: "fiche-catalogue", type: "Boolean" },
     },
@@ -29,16 +30,31 @@
   };
 
   interface Props {
+    /** Titre du bandeau */
     titre: string;
+    /** Balise HTML (Hn) du titre */
     baliseTitre: string;
+    /** Description du bandeau */
     description: string;
+    /** Mention du bandeau */
     mention: string;
-    inverse?: boolean;
+    /** Url de l'image */
     urlImage?: string | undefined;
+    /** Si "vrai", l'image n'est pas affichée */
     sansImage?: boolean;
+    /** Si "vrai", le fil d'Ariane est affiché */
     avecFilAriane?: boolean;
+    /** Segments du fil d'Ariane */
     liensFilAriane?: BreadcrumbSegment[];
+    /** Type du bandeau */
+    type?: "default" | "fiche" | "simple";
+    /** Thème du bandeau */
+    theme?: "clair" | "sombre";
+    /** Inversion du thème _(déprécié - préférer l'utilisation de la prop ``theme="inverse"``)_ */
+    inverse?: boolean;
+    /** Variation "Simple" _(déprécié - préférer l'utilisation de la prop ``type="simple"``)_ */
     simple?: boolean;
+    /** Variation "Fiche Catalogue" _(déprécié - préférer l'utilisation de la prop ``type="fiche"``)_ */
     ficheCatalogue?: boolean;
   }
 
@@ -47,25 +63,31 @@
     baliseTitre = "h1",
     description,
     mention,
-    inverse = false,
     urlImage,
     sansImage = false,
     avecFilAriane = false,
     liensFilAriane = [],
+    type = "default",
+    theme,
+    inverse = false,
     simple = false,
     ficheCatalogue = false,
   }: Props = $props();
+
+  const variationSimple = $derived(type === "simple" || simple);
+  const variationFiche = $derived(type === "fiche" || ficheCatalogue);
+  const themeClair = $derived(theme === "clair" || inverse);
 </script>
 
 <section
   class={[
     "lab-anssi-bandeau-page",
     {
-      "lab-anssi-bandeau-page--inverse": inverse,
+      "lab-anssi-bandeau-page--clair": themeClair,
       "lab-anssi-bandeau-page--sans-image": sansImage,
       "lab-anssi-bandeau-page--avec-filariane": avecFilAriane,
-      "lab-anssi-bandeau-page--simple": simple,
-      "lab-anssi-bandeau-page--fiche-catalogue": ficheCatalogue,
+      "lab-anssi-bandeau-page--simple": variationSimple,
+      "lab-anssi-bandeau-page--fiche-catalogue": variationFiche,
     },
   ]}
 >
@@ -76,7 +98,7 @@
         segments={liensFilAriane}
         buttonAriaLabel="vous êtes ici :"
         buttonLabel="Voir le fil d'Ariane"
-        inverse={!inverse}
+        inverse={!themeClair}
         hasMarginVariant
       />
     {/if}
@@ -93,7 +115,7 @@
 
         <p class="lab-anssi-bandeau-page__description">{description}</p>
 
-        {#if $$slots.buttonsgroup && !simple}
+        {#if $$slots.buttonsgroup && !variationSimple}
           <div class="lab-anssi-bandeau-page__actions">
             <slot name="buttonsgroup" />
           </div>
@@ -104,11 +126,13 @@
         {/if}
       </div>
 
-      {#if !sansImage && !simple}
+      {#if !sansImage && !variationSimple}
         <div class="lab-anssi-bandeau-page__secondaire">
-          <figure class="lab-anssi-bandeau-page__illustration">
-            <img src={urlImage} class="lab-anssi-bandeau-page__image" alt="" />
-          </figure>
+          <slot name="media">
+            <figure class="lab-anssi-bandeau-page__illustration">
+              <img src={urlImage} class="lab-anssi-bandeau-page__image" alt="" />
+            </figure>
+          </slot>
         </div>
       {/if}
     </div>
@@ -138,13 +162,13 @@
     }
 
     &__conteneur {
-      padding-block: 48px;
+      padding-block: rem(48px);
 
       @include respond-from("md") {
         display: flex;
         align-items: center;
-        margin: -0.75rem;
-        padding-block: 36px;
+        margin-inline: rem(-12px);
+        padding-block: rem(36px);
       }
     }
 
@@ -154,44 +178,44 @@
         flex: 0 0 50%;
         max-width: 50%;
         width: 50%;
-        padding: 0.75rem;
+        padding: rem(12px);
       }
     }
 
     &__principal {
       @include respond-to("sm") {
-        margin-block-end: 40px;
+        margin-block-end: rem(40px);
       }
     }
 
     &__titre {
       color: var(--text-color-titre);
       font-weight: 700;
-      font-size: 40px;
-      line-height: 48px;
-      margin-block: 0 12px;
+      font-size: rem(40px);
+      line-height: rem(48px);
+      margin-block: 0 rem(12px);
 
       @include respond-from("md") {
-        font-size: 48px;
-        line-height: 56px;
+        font-size: rem(48px);
+        line-height: rem(56px);
       }
     }
 
     &__description {
       color: var(--text-color-description);
-      font-size: 18px;
-      line-height: 28px;
+      font-size: rem(18px);
+      line-height: rem(28px);
       margin-block: 0;
 
       &:not(:last-child) {
-        margin-block-end: 24px;
+        margin-block-end: rem(24px);
       }
     }
 
     &__actions {
       display: flex;
       flex-direction: column;
-      gap: 16px;
+      gap: rem(16px);
 
       @include respond-from("md") {
         flex-direction: row;
@@ -200,8 +224,8 @@
 
     &__mention {
       color: var(--text-color-description);
-      font-size: 14px;
-      line-height: 24px;
+      font-size: rem(14px);
+      line-height: rem(24px);
       margin-block: 0;
     }
 
@@ -214,8 +238,8 @@
       max-width: 100%;
     }
 
-    // Variation "Inversé"
-    &--inverse {
+    // Variation "Clair"
+    &--clair {
       --background-color: var(--background-alt-blue-france);
       --text-color-titre: var(--text-title-grey);
       --text-color-description: var(--text-default-grey);
@@ -223,9 +247,9 @@
 
     // Variation "Avec Fil d'Ariane"
     &--avec-filariane {
-      --dsfr-breadcrumb-margin: 0 0 24px 0;
+      --dsfr-breadcrumb-margin: 0 0 rem(24px) 0;
 
-      padding-block-start: 16px;
+      padding-block-start: rem(16px);
 
       .lab-anssi-bandeau-page {
         &__conteneur {
@@ -241,16 +265,20 @@
         &__secondaire {
           padding-block-end: 0;
         }
+
+        &__secondaire {
+          align-self: flex-end;
+        }
       }
     }
 
     // Variation "Simple"
     &--simple {
-      --dsfr-breadcrumb-margin: 0 0 16px 0;
+      --dsfr-breadcrumb-margin: 0 0 rem(16px) 0;
 
       .lab-anssi-bandeau-page {
         &__conteneur {
-          padding-block-end: 12px;
+          padding-block-end: rem(12px);
         }
 
         &__principal {

--- a/stories/composants/BandeauPage.stories.svelte
+++ b/stories/composants/BandeauPage.stories.svelte
@@ -3,18 +3,56 @@
   import { type ComponentProps } from "svelte";
 
   import BandeauPage from "$lib/composants/BandeauPage.svelte";
+
   import DsfrBadgesGroup from "$lib/dsfr/DsfrBadgesGroup.svelte";
-  import DsfrBreadcrumb from "$lib/dsfr/DsfrBreadcrumb.svelte";
   import DsfrButtonsGroup from "$lib/dsfr/DsfrButtonsGroup.svelte";
 
   const { Story } = defineMeta({
     title: "Composants/Lab ANSSI/Bandeau page",
     component: BandeauPage,
     argTypes: {
-      actions: {
+      type: {
+        description: "Type du bandeau",
+        control: { type: "select" },
+        options: ["simple", "fiche"],
+      },
+      theme: {
+        description: "Thème du bandeau",
+        control: { type: "select" },
+        options: ["clair", "sombre"],
+      },
+      badgesgroup: {
+        description: "Groupe de badges affiché au-dessus du titre",
+        control: false,
+        table: { category: "Slots" },
+      },
+      buttonsgroup: {
         description: "Boutons ou liens d'action affichés sous la description du bandeau",
         control: false,
         table: { category: "Slots" },
+      },
+      media: {
+        description: "Contenu média affiché dans la partie secondaire (image par défaut)",
+        control: false,
+        table: { category: "Slots" },
+      },
+      inverse: {
+        table: { disable: true },
+      },
+      simple: {
+        table: { disable: true },
+      },
+      ficheCatalogue: {
+        table: { disable: true },
+      },
+      avecBadges: {
+        table: { disable: true },
+      },
+      boutons: {
+        table: { disable: true },
+      },
+      badges: {
+        table: { disable: true },
       },
     },
     args: {
@@ -22,7 +60,7 @@
       baliseTitre: "h1",
       description:
         "Lorem ipsum dolor sit amet, consectetur adipiscing elit. Cras tincidunt felis in velit semper euismod.",
-      inverse: false,
+      mention: "",
       urlImage: "/images/hero-placeholder.jpg",
       sansImage: false,
       boutons: [
@@ -73,7 +111,7 @@
 
   type Args = ComponentProps<BandeauPage>;
 
-  const boutonsInverse = [
+  const boutonsThemeClair = [
     {
       label: "Libellé",
       kind: "primary",
@@ -91,13 +129,12 @@
     balise-titre={args.baliseTitre}
     description={args.description}
     mention={args.mention}
-    inverse={args.inverse || undefined}
     url-image={args.urlImage}
     sans-image={args.sansImage || undefined}
     avec-fil-ariane={args.avecFilAriane || undefined}
     liens-fil-ariane={JSON.stringify(args.liensFilAriane)}
-    simple={args.simple || undefined}
-    fiche-catalogue={args.ficheCatalogue || undefined}
+    type={args.type}
+    theme={args.theme}
   >
     {#if args.avecBadges}
       <dsfr-badges-group slot="badgesgroup" badges={args.badges} size="md"></dsfr-badges-group>
@@ -105,14 +142,14 @@
 
     <dsfr-buttons-group
       slot="buttonsgroup"
-      buttons={args.boutons}
+      buttons={args.theme === "clair" ? boutonsThemeClair : args.boutons || []}
       inline="md"
       data-themeable="false"
     ></dsfr-buttons-group>
   </lab-anssi-bandeau-page>
 {/snippet}
 
-<Story name="Defaut" />
+<Story name="Par défaut" />
 
 <Story name="Avec Fil d'Ariane" args={{ avecFilAriane: true }} />
 
@@ -123,18 +160,12 @@
 
 <Story name="Avec un groupe de badges" args={{ avecBadges: true }} />
 
-<Story name="Inverse" args={{ inverse: true, boutons: boutonsInverse }} />
+<Story name="Thème Clair" args={{ theme: "clair" }} />
 
-<Story
-  name="Inverse (avec Fil d'Ariane)"
-  args={{ inverse: true, avecFilAriane: true, boutons: boutonsInverse }}
-/>
+<Story name="Thème Clair (avec Fil d'Ariane)" args={{ theme: "clair", avecFilAriane: true }} />
 
-<Story name="Simple" args={{ simple: true }} />
+<Story name="Simple" args={{ type: "simple" }} />
 
-<Story name="Simple (avec Fil d'Ariane)" args={{ simple: true, avecFilAriane: true }} />
+<Story name="Simple (avec Fil d'Ariane)" args={{ type: "simple", avecFilAriane: true }} />
 
-<Story
-  name="Fiche catalogue (avec Fil d'Ariane)"
-  args={{ ficheCatalogue: true, avecFilAriane: true }}
-/>
+<Story name="Fiche catalogue (avec Fil d'Ariane)" args={{ type: "fiche", avecFilAriane: true }} />


### PR DESCRIPTION
## Décrire les changements

Cette PR effectue plusieurs évolutions sur le composant `LabAnssiBandeauPage` qui sont les suivantes : 
- Ajoute les props `theme` & `type`. Ces propriétés visent à terme à remplacer l'usage des props `inverse`, `simple` & `ficheCatalogue`
- Corrige l'affichage de la variation `ficheCatalogue` afin de faire en sorte que l'image soit toujours férée en bas du bandeau
- Remplace l'usage des valeurs en `px` par des `rem` à l'aide de la mixin `rem()`
- Ajoute un slot `media` permettant de remplacer l'image par défaut

## Autres informations

<!-- Ajoutez ici tout autre commentaire ou toute autre information concernant cette Pull Request. -->
