### PR TITLE
[LAB] BlocFonctionnalites - Accepte les props complexes en tant que chaîne JSON

### DIFF
--- a/src/lib/composants/BlocFonctionnalites.svelte
+++ b/src/lib/composants/BlocFonctionnalites.svelte
@@ -129,6 +129,18 @@
 
   let indexActif = $state(0);
 
+  function parseJSON<T>(value: T | string): T {
+    return typeof value === "string" ? JSON.parse(value) : value;
+  }
+
+  const fonctionnalitesNormalisees: Fonctionnalite[] | Fonctionnalite[][] = $derived(
+    parseJSON(fonctionnalites),
+  );
+
+  const elementsDuControleSegmenteNormalises: Segmented[] = $derived(
+    parseJSON(elementsDuControleSegmente),
+  );
+
   /**
    * Vérifie si le tableau de fonctionnalités est un tableau multidimensionnel (tableau de tableaux)
    *
@@ -141,11 +153,13 @@
   }
 
   const tableauDeFonctionnalites = $derived(
-    estUnTableauImbrique(fonctionnalites) ? fonctionnalites : [fonctionnalites],
+    estUnTableauImbrique(fonctionnalitesNormalisees)
+      ? fonctionnalitesNormalisees
+      : [fonctionnalitesNormalisees],
   );
 
   const elementsModifiesDuControleSegmente = $derived(
-    elementsDuControleSegmente.map((element, index) => ({
+    elementsDuControleSegmenteNormalises.map((element, index) => ({
       ...element,
       value: element.value ? `liste-${element.value}` : `liste-${index + 1}`,
     })),

--- a/stories/composants/BlocFonctionnalites.stories.svelte
+++ b/stories/composants/BlocFonctionnalites.stories.svelte
@@ -163,7 +163,7 @@
         balise-titre={args.baliseTitre}
         avec-controle-segmente={args.avecControleSegmente || undefined}
         elements-du-controle-segmente={JSON.stringify(args.elementsDuControleSegmente)}
-        fonctionnalites={args.fonctionnalites}
+        fonctionnalites={JSON.stringify(args.fonctionnalites)}
         balise-des-sous-titres={args.baliseDesSousTitres}
         cliquable={args.cliquable || undefined}
         avec-cta={args.avecCTA || undefined}


### PR DESCRIPTION
## Décrire les changements

Accepte les props complexes en tant que chaîne JSON pour le composant `BlocFonctionnalites`.

## Cette PR introduit-elle un "breaking change" ?

- [ ] Yes
- [ ] No

## Autres informations

<!-- Ajoutez ici tout autre commentaire ou toute autre information concernant cette Pull Request. -->
