### PR TITLE
[COMPOSANT] `DsfrModal` - Personnalise le sélecteur du pied de page pour ne cibler que les `buttonsgroup`

### DIFF
--- a/src/lib/dsfr/DsfrModal.svelte
+++ b/src/lib/dsfr/DsfrModal.svelte
@@ -216,7 +216,7 @@
 
   @include set-shadow-host();
   @include set-dsfr-sizing("modal") {
-    :global(::slotted([slot="footer"])) {
+    :global(::slotted([slot="footer"]:where(dsfr-buttons-group, .fr-btns-group))) {
       margin-bottom: -1rem;
       width: calc(100% + 1rem);
     }

--- a/stories/dsfr/Modal.stories.svelte
+++ b/stories/dsfr/Modal.stories.svelte
@@ -105,8 +105,14 @@
       {@html body}
 
       {#if args.footer}
-        <dsfr-buttons-group slot="footer" {buttons} size="md" inline="lg" align="center"
-        ></dsfr-buttons-group>
+        {#if args.footerType === "buttonsgroup"}
+          <dsfr-buttons-group slot="footer" {buttons} size="md" inline="lg" align="center"
+          ></dsfr-buttons-group>
+        {/if}
+
+        {#if args.footerType === "button"}
+          <dsfr-button slot="footer" label="Bouton simple"></dsfr-button>
+        {/if}
       {/if}
     </dsfr-modal>
   </div>
@@ -121,11 +127,22 @@
 <Story name="Size LG" args={{ id: "modal-lg", size: "lg" }} />
 
 <Story
-  name="Footer"
+  name="Footer (avec DsfrButtonsGroup)"
   args={{
-    id: "modal-footer",
+    id: "modal-buttons-group",
     size: "md",
     footer: true,
+    footerType: "buttonsgroup",
+  }}
+/>
+
+<Story
+  name="Footer (avec DsfrButton)"
+  args={{
+    id: "modal-button",
+    size: "md",
+    footer: true,
+    footerType: "button",
   }}
 />
 


### PR DESCRIPTION
## Décrire les changements

`DsfrModal` - Personnalise le sélecteur du pied de page pour ne cibler que les `buttonsgroup`

## Autres informations

<!-- Ajoutez ici tout autre commentaire ou toute autre information concernant cette Pull Request. -->
