### PR TITLE
Ajoute du cache sur les versions déployées

### DIFF
--- a/.github/workflows/publication-npm.yml
+++ b/.github/workflows/publication-npm.yml
@@ -58,13 +58,13 @@ jobs:
           secret_key: ${{ secrets.CLEVER_S3_DES_ASSETS_SECRET_KEY }}
 
       - name: Envoyer les assets vers le CDN
-        run: s3cmd sync --recursive -M ./dist/assets/* s3://lab-anssi-ui-kit-prod-s3-assets
+        run: s3cmd sync --recursive -M --add-header='Cache-Control:public,max-age=3600' ./dist/assets/* s3://lab-anssi-ui-kit-prod-s3-assets
 
       - name: Envoyer la release js
-        run: s3cmd put --mime-type='application/javascript' ./dist/webcomponents/lab-anssi-ui-kit.iife.js "s3://lab-anssi-ui-kit-prod-s3-assets/${release_version}/"
+        run: s3cmd put --mime-type='application/javascript' --add-header='Cache-Control:public,max-age=31536000,immutable' ./dist/webcomponents/lab-anssi-ui-kit.iife.js "s3://lab-anssi-ui-kit-prod-s3-assets/${release_version}/"
 
       - name: Envoyer les feuilles de style des thèmes & du DSFR
         run: |
           for file in ./dist/assets/*.css; do
-            s3cmd put --mime-type='text/css' "$file" "s3://lab-anssi-ui-kit-prod-s3-assets/${release_version}/"
+            s3cmd put --mime-type='text/css' --add-header='Cache-Control:public,max-age=31536000,immutable' "$file" "s3://lab-anssi-ui-kit-prod-s3-assets/${release_version}/"
           done

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@lab-anssi/ui-kit",
-  "version": "1.60.1",
+  "version": "1.60.2",
   "repository": {
     "type": "git",
     "url": "git+https://github.com/betagouv/lab-anssi-ui-kit.git"

--- a/scripts/s3put_avec_le_bon_mime_type.sh
+++ b/scripts/s3put_avec_le_bon_mime_type.sh
@@ -21,15 +21,15 @@ mime_type() {
            ;;
     woff)  echo font/woff
            ;;
-    woff2) echo font/woff
+    woff2) echo font/woff2
            ;;
-    scg)   echo image/svg+xml
+    svg)   echo image/svg+xml
            ;;
-    *)     file --mime-type $file | cut -d: -f2 | tr -d ' '
+    *)     file --mime-type "$file" | cut -d: -f2 | tr -d ' '
   esac
 }
 
-for file in $(find storybook-static -type f)
+find storybook-static -type f | while IFS= read -r file
 do
   mime="$(mime_type "$file")"
   target="$(echo "$file" | sed -e s:^storybook-static/::)"


### PR DESCRIPTION
## Décrire les changements

Afin d'alléger la charge réseau, on souhaite ajouter du cache côté CDN.
On applique 2 politiques de cache distinctes :
- Immuable pour les fichiers versionnés (.js, .css)
- Courte pour les assets (`max-age=3600`, soit une heure)

## Cette PR introduit-elle un "breaking change" ?

- [ ] Yes
- [x] No

