### PR TITLE
[COMPOSANT] LabAnssiCentreAide - Ajoute l'attribut `data-open` sur le composant

### DIFF
--- a/src/lib/composants/CentreAide.svelte
+++ b/src/lib/composants/CentreAide.svelte
@@ -124,7 +124,7 @@
     border: 1px solid var(--background-default-grey);
     box-shadow: 0 0.25rem 0.75rem 0 rgba(0, 0, 18, 0.16);
     overflow: hidden;
-    z-index: 1000;
+    z-index: var(--z-index, 1000);
 
     @include a-partir-de(tablette) {
       bottom: 3rem;
@@ -139,7 +139,7 @@
     position: fixed;
     top: 0;
     width: 100%;
-    z-index: 9;
+    z-index: var(--z-index, 1000);
     overflow-y: scroll;
 
     @include a-partir-de(tablette) {

--- a/src/lib/composants/CentreAide.svelte
+++ b/src/lib/composants/CentreAide.svelte
@@ -39,6 +39,10 @@
   });
 
   let ouvert: boolean = $state(false);
+
+  $effect(() => {
+    $host()?.toggleAttribute("data-open", ouvert);
+  });
 </script>
 
 {#if !ouvert}

--- a/src/lib/composants/CentreAide.svelte
+++ b/src/lib/composants/CentreAide.svelte
@@ -44,6 +44,8 @@
   $effect(() => {
     $host()?.toggleAttribute("data-open", ouvert);
   });
+
+  const desktop = new MediaQuery("min-width: 992px");
 </script>
 
 {#if !ouvert}
@@ -54,6 +56,7 @@
       iconPlace="left"
       icon="question-line"
       onclick={() => (ouvert = true)}
+      size={desktop.current ? "lg" : "md"}
     />
   </div>
 {/if}

--- a/src/lib/composants/CentreAide.svelte
+++ b/src/lib/composants/CentreAide.svelte
@@ -3,6 +3,7 @@
 <script lang="ts">
   import { run } from "svelte/legacy";
   import { fly } from "svelte/transition";
+  import { MediaQuery } from "svelte/reactivity";
 
   import { setThemeable, withIconsStyleSheet } from "$lib/utilitaires";
 
@@ -166,11 +167,16 @@
   }
 
   .titre {
-    font-size: 1.5rem;
+    font-size: 1.375rem;
     font-style: normal;
     font-weight: 700;
-    line-height: 2rem;
+    line-height: 1.75rem;
     margin-block: 0;
+
+    @include a-partir-de(tablette) {
+      font-size: 1.5rem;
+      line-height: 2rem;
+    }
   }
 
   .contenu {


### PR DESCRIPTION
## Décrire les changements

Cette PR fait évoluer le composant **"Centre d'Aide"** en effectuant les implémentations suivants : 
- Ajout d'un attribut `data-open` sur le custom element dans le but que le consommateur du composant puisse faire des actions en fonction de l'état ouvert/fermé du composant
- Uniformisation des valeurs de `z-index` dans le but d'assurer au **"Centre d'Aide"** d'être positionner par dessus la majorité des éléments.
- Ajuste la taille du titre principal

## Autres informations

<!-- Ajoutez ici tout autre commentaire ou toute autre information concernant cette Pull Request. -->
