### PR TITLE
[CORRECTION] Corrige les problèmes d'affichage de la Suite Cyber

### DIFF
--- a/src/lib/composants/CentreAide.svelte
+++ b/src/lib/composants/CentreAide.svelte
@@ -128,7 +128,7 @@
     border: 1px solid var(--background-default-grey);
     box-shadow: 0 0.25rem 0.75rem 0 rgba(0, 0, 18, 0.16);
     overflow: hidden;
-    z-index: var(--z-index, 1000);
+    z-index: var(--centre-aide-z-index, 950);
 
     @include a-partir-de(tablette) {
       bottom: 3rem;
@@ -143,7 +143,7 @@
     position: fixed;
     top: 0;
     width: 100%;
-    z-index: var(--z-index, 1000);
+    z-index: var(--centre-aide-z-index, 950);
     overflow-y: scroll;
 
     @include a-partir-de(tablette) {

--- a/src/lib/composants/suite-cyber/SuiteCyber.svelte
+++ b/src/lib/composants/suite-cyber/SuiteCyber.svelte
@@ -178,7 +178,7 @@
     left: 0;
     overflow-y: scroll !important; // On force le scroll pour éviter qu'il soit masqué durant l'animation
     overflow-x: hidden;
-    z-index: $z-index-au-dessus;
+    z-index: var(--suite-cyber-z-index, $z-index-au-dessus);
     text-align: left;
 
     @include a-partir-de(desktop-dsfr) {

--- a/src/lib/dsfr/DsfrHeader.svelte
+++ b/src/lib/dsfr/DsfrHeader.svelte
@@ -608,6 +608,10 @@
         max-width: none;
       }
     }
+
+    &__brand-top {
+      overflow: var(--brand-top-overflow, hidden);
+    }
   }
 
   .fr-header :global(.fr-nav__list) {


### PR DESCRIPTION
## Décrire les changements

Cette PR a pour but de faire évoluer plusieurs composants dans le but de gérer au mieux l'affichage de la SuiteCyber.
Ainssi cette PR effectue les implémentations suivantes : 
- Sur le `DsfrHeader` : Ajoute la possibilité de personnaliser la propriété `overflow` sur la class `.fr-header__brand-top`. Cette propriété `overflow: hidden` semble être la cause des bugs d'affichage de la **Suite Cyber** sur **iOS**. 
- Sur le composant `LabAnssiSuiteCyber` : Ajoute la possibilité de personnaliser le `z-index` à l'aide d'une variable CSS `--z-index`.
- Sur le composant `LabAnssiCentreAide` : Réduit la valeur du `z-index` par défaut, afin que par défaut le **"Centre d'aide"** ne passe pas au dessus de la **"Suite Cyber"**

## Autres informations

<!-- Ajoutez ici tout autre commentaire ou toute autre information concernant cette Pull Request. -->
