### PR TITLE
[VITE] Monte la version de Vite vers la version majeure Vite 8

### DIFF
--- a/.storybook/main.ts
+++ b/.storybook/main.ts
@@ -1,11 +1,7 @@
-import { fileURLToPath } from "node:url";
 import type { StorybookConfig } from "@storybook/svelte-vite";
-import path, { dirname } from "path";
+import path from "path";
 import { loadEnv } from "vite";
 import viteScssPreprocessorOptions from "../outils/vite-preprocessor-options.ts";
-
-const __filename = fileURLToPath(import.meta.url);
-const __dirname = dirname(__filename);
 
 const varEnv = loadEnv(process.env.STORYBOOK_ENV ?? "production", process.cwd(), "VITE_");
 
@@ -40,8 +36,8 @@ const config: StorybookConfig = {
     };
     config.resolve = {
       alias: {
-        src: path.resolve(__dirname, "../src"),
-        $lib: path.resolve(__dirname, "../src/lib"),
+        src: path.resolve(import.meta.dirname, "../src"),
+        $lib: path.resolve(import.meta.dirname, "../src/lib"),
       },
     };
     config.css = {

--- a/outils/index.ts
+++ b/outils/index.ts
@@ -1,10 +1,10 @@
 import { loadEnv } from "vite";
 
-export { default as extractDataUriSvg } from "./postcss-extract-data-uri-svg";
-export { default as replaceIconPaths } from "./postcss-replace-icon-paths";
-export { default as genereJSX } from "./vite-plugin-genere-jsx";
-export { default as injecteNonce } from "./vite-plugin-injecte-nonce";
-export { default as viteScssPreprocessorOptions } from "./vite-preprocessor-options";
+export { default as extractDataUriSvg } from "./postcss-extract-data-uri-svg.ts";
+export { default as replaceIconPaths } from "./postcss-replace-icon-paths.ts";
+export { default as genereJSX } from "./vite-plugin-genere-jsx.ts";
+export { default as injecteNonce } from "./vite-plugin-injecte-nonce.ts";
+export { default as viteScssPreprocessorOptions } from "./vite-preprocessor-options.ts";
 
 // Variables d'environnement chargées selon le contexte d'exécution.
 // Charge le bon environnement pour faire fonctionner la fonction SCSS `url-asset()`

--- a/outils/injection-nonce.ts
+++ b/outils/injection-nonce.ts
@@ -1,15 +1,30 @@
 export const injecteNonceWebcomponents = (code: string) => {
   let codeAvecNonce = `const nonce = document.currentScript?.nonce;\n${code}`;
 
+  let nombreInjections = 0;
+
   codeAvecNonce = codeAvecNonce
     .replace(
-      /const (\w+)\s*=\s*\w+\(["']style["']\);/gm,
-      (match, nomVariable) => `${match}${nomVariable}.nonce=nonce;`,
+      /(?:const|let|var)\s+(\w+)\s*=\s*\w+\(["'`]style["'`]\)\s*[;,]/gm,
+      (match, nomVariable) => {
+        nombreInjections++;
+        return `${match}${nomVariable}.nonce=nonce;`;
+      },
     )
     .replace(
-      /const (\w+)\s*=\s*document\.createElement\(["']style["']\);/gm,
-      (match, nomVariable) => `${match}${nomVariable}.nonce=nonce;`,
+      /(?:const|let|var)\s+(\w+)\s*=\s*document\.createElement\(["'`]style["'`]\)\s*[;,]/gm,
+      (match, nomVariable) => {
+        nombreInjections++;
+        return `${match}${nomVariable}.nonce=nonce;`;
+      },
     );
+
+  if (nombreInjections === 0) {
+    throw new Error(
+      "Le plugin injecteNonce n'a trouvé aucun pattern de création de <style> à injecter. " +
+        "Le format du bundle produit par Vite a peut-être changé.",
+    );
+  }
 
   return codeAvecNonce;
 };

--- a/outils/vite-plugin-genere-jsx.ts
+++ b/outils/vite-plugin-genere-jsx.ts
@@ -4,7 +4,7 @@ import type { Plugin } from "vite";
 import * as ts from "typescript";
 import * as prettier from "prettier";
 import { parse } from "svelte/compiler";
-import { extraitPropsComposant } from "./extraction-props-composant";
+import { extraitPropsComposant } from "./extraction-props-composant.ts";
 
 /**
  * Extrait le contenu de la balise <script> d'un composant Svelte

--- a/outils/vite-plugin-injecte-nonce.ts
+++ b/outils/vite-plugin-injecte-nonce.ts
@@ -1,5 +1,5 @@
 import type { Plugin } from "vite";
-import { injecteNonceWebcomponents } from "./injection-nonce";
+import { injecteNonceWebcomponents } from "./injection-nonce.ts";
 
 export default function injecteNonce(): Plugin {
   return {

--- a/package.json
+++ b/package.json
@@ -65,7 +65,7 @@
     "@storybook/addon-themes": "~10.5.9",
     "@storybook/addon-vitest": "~10.5.9",
     "@storybook/svelte-vite": "~10.5.9",
-    "@sveltejs/vite-plugin-svelte": "~6.2.4",
+    "@sveltejs/vite-plugin-svelte": "~7.3.0",
     "@testing-library/jest-dom": "~7.0.0",
     "@testing-library/svelte": "~5.4.2",
     "@types/node": "~24.13.3",
@@ -97,7 +97,7 @@
     "svelte-check": "~4.7.6",
     "typescript": "~6.0.3",
     "typescript-eslint": "~8.67.0",
-    "vite": "~7.3.6",
+    "vite": "~8.2.1",
     "vitest": "~4.1.10",
     "wait-on": "~9.1.0"
   },

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -236,10 +236,10 @@ importers:
         version: 10.5.9(storybook@10.5.9(@types/react@19.2.15)(prettier@3.9.6)(react@19.2.8))
       '@storybook/addon-docs':
         specifier: ~10.5.9
-        version: 10.5.9(@types/react@19.2.15)(esbuild@0.28.2)(rollup@4.62.4)(storybook@10.5.9(@types/react@19.2.15)(prettier@3.9.6)(react@19.2.8))(vite@7.3.6(@types/node@24.13.3)(sass@1.103.0)(yaml@2.9.0))
+        version: 10.5.9(@types/react@19.2.15)(esbuild@0.28.2)(rollup@4.62.4)(storybook@10.5.9(@types/react@19.2.15)(prettier@3.9.6)(react@19.2.8))(vite@8.2.1(@types/node@24.13.3)(esbuild@0.28.2)(sass@1.103.0)(yaml@2.9.0))
       '@storybook/addon-svelte-csf':
         specifier: ~5.1.2
-        version: 5.1.2(@storybook/svelte@10.5.9(storybook@10.5.9(@types/react@19.2.15)(prettier@3.9.6)(react@19.2.8))(svelte@5.56.9(@typescript-eslint/types@8.67.0)))(@sveltejs/vite-plugin-svelte@6.2.4(svelte@5.56.9(@typescript-eslint/types@8.67.0))(vite@7.3.6(@types/node@24.13.3)(sass@1.103.0)(yaml@2.9.0)))(storybook@10.5.9(@types/react@19.2.15)(prettier@3.9.6)(react@19.2.8))(svelte@5.56.9(@typescript-eslint/types@8.67.0))(vite@7.3.6(@types/node@24.13.3)(sass@1.103.0)(yaml@2.9.0))
+        version: 5.1.2(@storybook/svelte@10.5.9(storybook@10.5.9(@types/react@19.2.15)(prettier@3.9.6)(react@19.2.8))(svelte@5.56.9(@typescript-eslint/types@8.67.0)))(@sveltejs/vite-plugin-svelte@7.3.0(svelte@5.56.9(@typescript-eslint/types@8.67.0))(vite@8.2.1(@types/node@24.13.3)(esbuild@0.28.2)(sass@1.103.0)(yaml@2.9.0)))(storybook@10.5.9(@types/react@19.2.15)(prettier@3.9.6)(react@19.2.8))(svelte@5.56.9(@typescript-eslint/types@8.67.0))(vite@8.2.1(@types/node@24.13.3)(esbuild@0.28.2)(sass@1.103.0)(yaml@2.9.0))
       '@storybook/addon-themes':
         specifier: ~10.5.9
         version: 10.5.9(storybook@10.5.9(@types/react@19.2.15)(prettier@3.9.6)(react@19.2.8))
@@ -248,25 +248,25 @@ importers:
         version: 10.5.9(@vitest/browser-playwright@4.1.11)(@vitest/browser@4.1.11)(@vitest/runner@4.1.11)(react@19.2.8)(storybook@10.5.9(@types/react@19.2.15)(prettier@3.9.6)(react@19.2.8))(vitest@4.1.11)
       '@storybook/svelte-vite':
         specifier: ~10.5.9
-        version: 10.5.9(@sveltejs/vite-plugin-svelte@6.2.4(svelte@5.56.9(@typescript-eslint/types@8.67.0))(vite@7.3.6(@types/node@24.13.3)(sass@1.103.0)(yaml@2.9.0)))(esbuild@0.28.2)(rollup@4.62.4)(storybook@10.5.9(@types/react@19.2.15)(prettier@3.9.6)(react@19.2.8))(svelte@5.56.9(@typescript-eslint/types@8.67.0))(vite@7.3.6(@types/node@24.13.3)(sass@1.103.0)(yaml@2.9.0))
+        version: 10.5.9(@sveltejs/vite-plugin-svelte@7.3.0(svelte@5.56.9(@typescript-eslint/types@8.67.0))(vite@8.2.1(@types/node@24.13.3)(esbuild@0.28.2)(sass@1.103.0)(yaml@2.9.0)))(esbuild@0.28.2)(rollup@4.62.4)(storybook@10.5.9(@types/react@19.2.15)(prettier@3.9.6)(react@19.2.8))(svelte@5.56.9(@typescript-eslint/types@8.67.0))(vite@8.2.1(@types/node@24.13.3)(esbuild@0.28.2)(sass@1.103.0)(yaml@2.9.0))
       '@sveltejs/vite-plugin-svelte':
-        specifier: ~6.2.4
-        version: 6.2.4(svelte@5.56.9(@typescript-eslint/types@8.67.0))(vite@7.3.6(@types/node@24.13.3)(sass@1.103.0)(yaml@2.9.0))
+        specifier: ~7.3.0
+        version: 7.3.0(svelte@5.56.9(@typescript-eslint/types@8.67.0))(vite@8.2.1(@types/node@24.13.3)(esbuild@0.28.2)(sass@1.103.0)(yaml@2.9.0))
       '@testing-library/jest-dom':
         specifier: ~7.0.0
         version: 7.0.1(@testing-library/dom@10.4.1)(vitest@4.1.11)
       '@testing-library/svelte':
         specifier: ~5.4.2
-        version: 5.4.2(svelte@5.56.9(@typescript-eslint/types@8.67.0))(vite@7.3.6(@types/node@24.13.3)(sass@1.103.0)(yaml@2.9.0))(vitest@4.1.11)
+        version: 5.4.2(svelte@5.56.9(@typescript-eslint/types@8.67.0))(vite@8.2.1(@types/node@24.13.3)(esbuild@0.28.2)(sass@1.103.0)(yaml@2.9.0))(vitest@4.1.11)
       '@types/node':
         specifier: ~24.13.3
         version: 24.13.3
       '@vitest/browser':
         specifier: ~4.1.10
-        version: 4.1.11(vite@7.3.6(@types/node@24.13.3)(sass@1.103.0)(yaml@2.9.0))(vitest@4.1.11)
+        version: 4.1.11(vite@8.2.1(@types/node@24.13.3)(esbuild@0.28.2)(sass@1.103.0)(yaml@2.9.0))(vitest@4.1.11)
       '@vitest/browser-playwright':
         specifier: ~4.1.10
-        version: 4.1.11(playwright@1.62.1)(vite@7.3.6(@types/node@24.13.3)(sass@1.103.0)(yaml@2.9.0))(vitest@4.1.11)
+        version: 4.1.11(playwright@1.62.1)(vite@8.2.1(@types/node@24.13.3)(esbuild@0.28.2)(sass@1.103.0)(yaml@2.9.0))(vitest@4.1.11)
       '@vitest/coverage-v8':
         specifier: ~4.1.10
         version: 4.1.11(@vitest/browser@4.1.11)(vitest@4.1.11)
@@ -346,11 +346,11 @@ importers:
         specifier: ~8.67.0
         version: 8.67.0(eslint@10.8.1(supports-color@10.2.2))(supports-color@10.2.2)(typescript@6.0.3)
       vite:
-        specifier: ~7.3.6
-        version: 7.3.6(@types/node@24.13.3)(sass@1.103.0)(yaml@2.9.0)
+        specifier: ~8.2.1
+        version: 8.2.1(@types/node@24.13.3)(esbuild@0.28.2)(sass@1.103.0)(yaml@2.9.0)
       vitest:
         specifier: ~4.1.10
-        version: 4.1.11(@types/node@24.13.3)(@vitest/browser-playwright@4.1.11)(@vitest/coverage-v8@4.1.11)(vite@7.3.6(@types/node@24.13.3)(sass@1.103.0)(yaml@2.9.0))
+        version: 4.1.11(@types/node@24.13.3)(@vitest/browser-playwright@4.1.11)(@vitest/coverage-v8@4.1.11)(vite@8.2.1(@types/node@24.13.3)(esbuild@0.28.2)(sass@1.103.0)(yaml@2.9.0))
       wait-on:
         specifier: ~9.1.0
         version: 9.1.0(debug@4.4.3(supports-color@10.2.2))(supports-color@10.2.2)
@@ -982,6 +982,9 @@ packages:
   '@oxc-project/types@0.127.0':
     resolution: {integrity: sha512-aIYXQBo4lCbO4z0R3FHeucQHpF46l2LbMdxRvqvuRuW2OxdnSkcng5B8+K12spgLDj93rtN3+J2Vac/TIO+ciQ==}
 
+  '@oxc-project/types@0.144.0':
+    resolution: {integrity: sha512-nuhZIOLuI6TFQ32I/WnUx+SCPY7SdSKwgnFHydAuoS1+Z4BRcaP+RRJmGzl9lw+0OFF7UmaESf7KQRXaNLHypg==}
+
   '@oxc-resolver/binding-android-arm-eabi@11.24.2':
     resolution: {integrity: sha512-y09e0L0SRI2OA2tUIrjBgoV3eH5hvUKXNkJqXmNo5V2WxIjyC7I7aJfRLMEVpA8yi95f90gFDvO0VMgrDw+vwA==}
     cpu: [arm]
@@ -1173,6 +1176,99 @@ packages:
   '@publint/pack@0.1.7':
     resolution: {integrity: sha512-4EDEmvxWtgsCnnVeBvtFIFZtUhPPt1+bA9JrSwU4Sa//6oKtzCSlGGXYJr44OD9aGISymbieJ4mCKHUygUDU+g==}
     engines: {node: '>=18'}
+
+  '@rolldown/binding-android-arm64@1.2.4':
+    resolution: {integrity: sha512-jHC2cnyKz5xU2fhECtFl8OZ83cYNt13GZQD+0uMJ/X3o+ijmd56okHhTUwxVSHPx1IRVIJEZ1/1pPzeLCU6XKA==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [arm64]
+    os: [android]
+
+  '@rolldown/binding-darwin-arm64@1.2.4':
+    resolution: {integrity: sha512-Dc5mPD8F5F/FS8i01syd7FTF6yB2fVthH/TRkjwJkzUK6EpoxHtqvZQP5Zwq80/5z19TWYHIg1KOHboCgVx/aQ==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [arm64]
+    os: [darwin]
+
+  '@rolldown/binding-darwin-x64@1.2.4':
+    resolution: {integrity: sha512-fpDm4oBo6SqLvWUYCmFhdde3U9KH2fRNNMeAnAPAIwxRL345xutL0EtEUcuoxsoazdJGv/MuDBQHlCDrtbvqOg==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [x64]
+    os: [darwin]
+
+  '@rolldown/binding-freebsd-x64@1.2.4':
+    resolution: {integrity: sha512-rSJoreDE/HoIzoaib6MTp5jQtCTdMHKIvItAKT/ImS6Y6Ww76oUaeMyp4Vc/fAgd/ehji068IxetHXAnqUwN9A==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [x64]
+    os: [freebsd]
+
+  '@rolldown/binding-linux-arm-gnueabihf@1.2.4':
+    resolution: {integrity: sha512-/jm8OGHgn7oGaJu3i/qZI9spUGcJ+y/lk43ttQ/iO1tOd9NissG6o97bighBCiL+BKRngmcDuR6ikfwYdJmVuQ==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [arm]
+    os: [linux]
+
+  '@rolldown/binding-linux-arm64-gnu@1.2.4':
+    resolution: {integrity: sha512-tIP06BeD9EqvECBrPZ+sqdPlYrT+aYaAiu1wYziVx5elRK/ftm33JxVDy2bXGbr6J0CrtirCkR87/X5a2euEng==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [arm64]
+    os: [linux]
+    libc: [glibc]
+
+  '@rolldown/binding-linux-arm64-musl@1.2.4':
+    resolution: {integrity: sha512-Ql1Q0EQqVThvn9VAVlwNzsUvbSFtCMGjLpRRi4pk5i7NZZ4n5ISiLMjHYtus4VQ2PvkSw24zyaCVsiS+sXPj1w==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [arm64]
+    os: [linux]
+    libc: [musl]
+
+  '@rolldown/binding-linux-ppc64-gnu@1.2.4':
+    resolution: {integrity: sha512-GjbjXD4XXfN19D0LZNbmiCBUoDiRACsYHr0yaIbbn8aFsXjHZifcYqu/W5Er5X2X990WjHXFrxarn5chzItorQ==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [ppc64]
+    os: [linux]
+    libc: [glibc]
+
+  '@rolldown/binding-linux-s390x-gnu@1.2.4':
+    resolution: {integrity: sha512-p5WR0NOwaRmJ/B1b6IjEFLLivwEsf3PrdBIhRbhTCQisbo2SvHHpG4ELB/+FgQNnB88LTOF86upmJmbvZdQ2lw==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [s390x]
+    os: [linux]
+    libc: [glibc]
+
+  '@rolldown/binding-linux-x64-gnu@1.2.4':
+    resolution: {integrity: sha512-4/GyVjmhR+Tc6HLJvwc1sOhPqAZtySiSMesOZyX6JQ5XBxoTDEMKQzvo07NIK6nTon/SivlZqvhzvuVBNQhObQ==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [x64]
+    os: [linux]
+    libc: [glibc]
+
+  '@rolldown/binding-linux-x64-musl@1.2.4':
+    resolution: {integrity: sha512-l9eeLsCNvPpmSXUej0etw/J1eqV0Jj1D5G/xG6YTijmE6dkv6E2QezgWbTfQk63v952DPqrjOCoiqxq7Bw0YUQ==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [x64]
+    os: [linux]
+    libc: [musl]
+
+  '@rolldown/binding-openharmony-arm64@1.2.4':
+    resolution: {integrity: sha512-e0F355MSTMm3+UOqtV3L24gFUp2N5m1f8L/7d56deik6va+AXdrt9F8LbzGpeWGWRbZEDq4m8NVnJDeBtf9DZg==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [arm64]
+    os: [openharmony]
+
+  '@rolldown/binding-win32-arm64-msvc@1.2.4':
+    resolution: {integrity: sha512-AWLi0uBRYh6QlE7OKhiz+phZC0qwtij2QZmhmOdsLdFn64m7oMpooE9ICE3lhm9xMb4SpDo2WbHcxX1iFLFtqw==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [arm64]
+    os: [win32]
+
+  '@rolldown/binding-win32-x64-msvc@1.2.4':
+    resolution: {integrity: sha512-UwSDJOg3dqCAejWdxclJjCsh3Qq4vLYMDxmyHqo1btz3stK2VqgwNd3mm5tuIwzSlGIQ/1H9Hr+Zn09mrezNqQ==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [x64]
+    os: [win32]
+
+  '@rolldown/pluginutils@1.0.1':
+    resolution: {integrity: sha512-2j9bGt5Jh8hj+vPtgzPtl72j0yRxHAyumoo6TNfAjsLB04UtpSvPbPcDcBMxz7n+9CYB0c1GxQFxYRg2jimqGw==}
 
   '@rollup/rollup-android-arm-eabi@4.62.4':
     resolution: {integrity: sha512-RrPokAb7dmbxFoeO3TloqHyOjgye8RkBhSqmp4aJMIex4c9r46ZstPnleDQOq1t46VOVjwIuwNogIqbodV1Vvg==}
@@ -1433,20 +1529,12 @@ packages:
     resolution: {integrity: sha512-VT3qmUb8pRV2QrZjd8iAmtg8lf4W0TIjZbvXtz5MKei/q96teWZgGJyyidJzOjzZzvdq616eSRVeMYIQChUTAQ==}
     engines: {node: '>= 18.0.0'}
 
-  '@sveltejs/vite-plugin-svelte-inspector@5.0.2':
-    resolution: {integrity: sha512-TZzRTcEtZffICSAoZGkPSl6Etsj2torOVrx6Uw0KpXxrec9Gg6jFWQ60Q3+LmNGfZSxHRCZL7vXVZIWmuV50Ig==}
+  '@sveltejs/vite-plugin-svelte@7.3.0':
+    resolution: {integrity: sha512-QbRoJyD92e9R0ufeQIWRHrCC0ObcqSv/aBDdrQMoU+sypav3cDx5wytdQ6GLdXjEMO6xjrXGzfkUygng8JMv0A==}
     engines: {node: ^20.19 || ^22.12 || >=24}
     peerDependencies:
-      '@sveltejs/vite-plugin-svelte': ^6.0.0-next.0
-      svelte: ^5.0.0
-      vite: ^6.3.0 || ^7.0.0
-
-  '@sveltejs/vite-plugin-svelte@6.2.4':
-    resolution: {integrity: sha512-ou/d51QSdTyN26D7h6dSpusAKaZkAiGM55/AKYi+9AGZw7q85hElbjK3kEyzXHhLSnRISHOYzVge6x0jRZ7DXA==}
-    engines: {node: ^20.19 || ^22.12 || >=24}
-    peerDependencies:
-      svelte: ^5.0.0
-      vite: ^6.3.0 || ^7.0.0
+      svelte: ^5.46.4
+      vite: ^8.0.0-beta.7 || ^8.0.0
 
   '@testing-library/dom@10.4.1':
     resolution: {integrity: sha512-o4PXJQidqJl82ckFaXUeoAW+XysPLauYI43Abki5hABd853iMhitooc6znOnczgbTYmEP6U6/y1ZyKAIsvMKGg==}
@@ -2509,6 +2597,80 @@ packages:
     resolution: {integrity: sha512-+bT2uH4E5LGE7h/n3evcS/sQlJXCpIp6ym8OWJ5eV6+67Dsql/LaaT7qJBAt2rzfoa/5QBGBhxDix1dMt2kQKQ==}
     engines: {node: '>= 0.8.0'}
 
+  lightningcss-android-arm64@1.33.0:
+    resolution: {integrity: sha512-gEpRTalKdosp4Bb8qWtc2iOgE5SeIHlpS1up9bFq2wAyYhl1UdTObYiHe98zEM9SQvSoqQZ1IQD0JNpg3Ml5pg==}
+    engines: {node: '>= 12.0.0'}
+    cpu: [arm64]
+    os: [android]
+
+  lightningcss-darwin-arm64@1.33.0:
+    resolution: {integrity: sha512-Sciaz8eenNTKn9b3t7+xr0ipTp9YxKQY4npwQ3mrRuL0BAVHBLyZxofhaKBAVtzmtRZ/zTyo0/to4B1uWG/Djg==}
+    engines: {node: '>= 12.0.0'}
+    cpu: [arm64]
+    os: [darwin]
+
+  lightningcss-darwin-x64@1.33.0:
+    resolution: {integrity: sha512-Z5UPAxzrjlWNNyGy6i65cJzzvgJ5D3T6wMvs+gWpY9d7qRhANrxqAp6LhxIgZhWEw18RfJTGcRxjuLIBr+m8XQ==}
+    engines: {node: '>= 12.0.0'}
+    cpu: [x64]
+    os: [darwin]
+
+  lightningcss-freebsd-x64@1.33.0:
+    resolution: {integrity: sha512-QQM/Ti/hQajJwCY+RiWuCZ9sdtI/XQk7nDK5vC8kkdwixezOlDgvDx7+RT+QjK6FcFT4MpsuoBnHIo/O3StRRg==}
+    engines: {node: '>= 12.0.0'}
+    cpu: [x64]
+    os: [freebsd]
+
+  lightningcss-linux-arm-gnueabihf@1.33.0:
+    resolution: {integrity: sha512-N7FVBe6iS24MlM6R/4RBTxGhQheZGs7tiQ9U32UtF75NzP5Q7xWPRqLBCKxlRQRk3rY1jCIPLzx7WzOhuUIRLQ==}
+    engines: {node: '>= 12.0.0'}
+    cpu: [arm]
+    os: [linux]
+
+  lightningcss-linux-arm64-gnu@1.33.0:
+    resolution: {integrity: sha512-j2v/itmy4HlNxlc6voKXYgBqNi0Ng2LShg4z7GufpEgs05P+2suBVyi9I6YHq5uoVFx9ETin3eCEhLVyXGQnKg==}
+    engines: {node: '>= 12.0.0'}
+    cpu: [arm64]
+    os: [linux]
+    libc: [glibc]
+
+  lightningcss-linux-arm64-musl@1.33.0:
+    resolution: {integrity: sha512-yiO5ROMuYQgXbC60yjZU5CYSFZGKXL0HFATXt9mHJn1+zW55oCtMI9NfcVhYLMFDL7gV7oBPon/EmMMGg2OvtQ==}
+    engines: {node: '>= 12.0.0'}
+    cpu: [arm64]
+    os: [linux]
+    libc: [musl]
+
+  lightningcss-linux-x64-gnu@1.33.0:
+    resolution: {integrity: sha512-ar+Ju7LmcN0Jo4FpL4hpFybwNG9/3A/Br5KW2n2jyODg3MEZXaDYADdemoNS+BDNfMgKvylJLj4S5tyRActuAg==}
+    engines: {node: '>= 12.0.0'}
+    cpu: [x64]
+    os: [linux]
+    libc: [glibc]
+
+  lightningcss-linux-x64-musl@1.33.0:
+    resolution: {integrity: sha512-RYiYbkokw0trfKqqzfF55lginwEPrD3OJDfTuJzFs1MK6iFnDenaz1fqLLtX4ITG3OktJQXOeTaw1awrBAlZPw==}
+    engines: {node: '>= 12.0.0'}
+    cpu: [x64]
+    os: [linux]
+    libc: [musl]
+
+  lightningcss-win32-arm64-msvc@1.33.0:
+    resolution: {integrity: sha512-1K+MPfLSFVpphzpdbfkhlWk6wBrTObBzS2T6db10PNOZgR9GoVsAWzwNyuhUYYbTp23j+4RrncfujZ4uAzXvwA==}
+    engines: {node: '>= 12.0.0'}
+    cpu: [arm64]
+    os: [win32]
+
+  lightningcss-win32-x64-msvc@1.33.0:
+    resolution: {integrity: sha512-OlEICDx/Xl0FqSp4bry8zFnCvGpig3Gl4gCquvYwHuqJKEC1+n9NgDniFvqHGmMv1ZkqDJrDqKKSykTDX+ehuA==}
+    engines: {node: '>= 12.0.0'}
+    cpu: [x64]
+    os: [win32]
+
+  lightningcss@1.33.0:
+    resolution: {integrity: sha512-WkUDrojuJs0xkgGf2udWxa3yGBRxPtxUkB79i6aCZLRgc7PM8fZe9TosfPDcvEpQZbuFASnHYmRLBLUbmLOIIA==}
+    engines: {node: '>= 12.0.0'}
+
   lilconfig@2.1.0:
     resolution: {integrity: sha512-utWOt/GHzuUxnLKxB6dk81RoOeoNeHgbrXiuGk4yyF5qlRz+iIVWu56E2fqGHFrXz0QNUhLB/8nKqvRH66JKGQ==}
     engines: {node: '>=10'}
@@ -2545,6 +2707,9 @@ packages:
 
   magic-string@0.30.21:
     resolution: {integrity: sha512-vd2F4YUyEXKGcLHoq+TEyCjxueSeHnFxyyjNp80yg0XV4vUhnDer/lvvlqM/arB5bXQN5K2/3oinyCRyx8T2CQ==}
+
+  magic-string@1.2.0:
+    resolution: {integrity: sha512-ptco+HFxTLgjafSLim2LojBSwfg5feBjd+SqyiwdGkzC38UPdZy3zgrHMI2CoTf5fJL38tbHMYWVzIH8BxGqJw==}
 
   magicast@0.5.4:
     resolution: {integrity: sha512-llBEhWm1SacoRwgHUoQJYtwp4PBLF4faQi5TCpIGyGs9n4y5+juI0tDgyKIfpqxckRHaHzouUEph3THklWh03w==}
@@ -3024,6 +3189,11 @@ packages:
     resolution: {integrity: sha512-g6QUff04oZpHs0eG5p83rFLhHeV00ug/Yf9nZM6fLeUrPguBTkTQOdpAWWspMh55TZfVQDPaN3NQJfbVRAxdIw==}
     engines: {iojs: '>=1.0.0', node: '>=0.10.0'}
 
+  rolldown@1.2.4:
+    resolution: {integrity: sha512-rSr7irW0K7QRWzjdJXqZowkcRdDtjRduh43rBltnVKd0VFq839l1lJoDvGJb6gl7+4rTTCrPWu+YfujUL8Ug7w==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    hasBin: true
+
   rollup@4.62.4:
     resolution: {integrity: sha512-RXOqwaPsBGjMNMa4sQjDjHieHEZDFoj/Rdr46l2MU5DfEs16wHJPC2RPTPHWhNl+M3aI472LLqFkFKut4SblOg==}
     engines: {node: '>=18.0.0', npm: '>=8.0.0'}
@@ -3370,15 +3540,16 @@ packages:
   util@0.12.5:
     resolution: {integrity: sha512-kZf/K6hEIrWHI6XqOFUiiMa+79wE/D8Q+NCNAWclkyg3b4d2k7s0QGepNjiABc+aR3N1PAyHL7p6UcLY6LmrnA==}
 
-  vite@7.3.6:
-    resolution: {integrity: sha512-4XP60spRGjSZFf1qYH+dJIkK2znL3zQfl9KkOV9MkkRR/3Dls0dxaBsQPTloEc5BLXWPL9vsOxopxyKoMmDueg==}
+  vite@8.2.1:
+    resolution: {integrity: sha512-EU/eS7BH3XROHh2YnBefjM6DBKA6ZeMZEYQbj7NLWg5wHYlhB8B/Mayd5XsgWq+NFYccDOTemRpdETWR6Ka/lw==}
     engines: {node: ^20.19.0 || >=22.12.0}
     hasBin: true
     peerDependencies:
       '@types/node': ^20.19.0 || >=22.12.0
+      '@vitejs/devtools': ^0.4.0
+      esbuild: ^0.27.0 || ^0.28.0
       jiti: '>=1.21.0'
       less: ^4.0.0
-      lightningcss: ^1.21.0
       sass: ^1.70.0
       sass-embedded: ^1.70.0
       stylus: '>=0.54.8'
@@ -3389,11 +3560,13 @@ packages:
     peerDependenciesMeta:
       '@types/node':
         optional: true
+      '@vitejs/devtools':
+        optional: true
+      esbuild:
+        optional: true
       jiti:
         optional: true
       less:
-        optional: true
-      lightningcss:
         optional: true
       sass:
         optional: true
@@ -4047,6 +4220,8 @@ snapshots:
 
   '@oxc-project/types@0.127.0': {}
 
+  '@oxc-project/types@0.144.0': {}
+
   '@oxc-resolver/binding-android-arm-eabi@11.24.2':
     optional: true
 
@@ -4171,6 +4346,50 @@ snapshots:
     dependencies:
       tinyexec: 1.3.0
 
+  '@rolldown/binding-android-arm64@1.2.4':
+    optional: true
+
+  '@rolldown/binding-darwin-arm64@1.2.4':
+    optional: true
+
+  '@rolldown/binding-darwin-x64@1.2.4':
+    optional: true
+
+  '@rolldown/binding-freebsd-x64@1.2.4':
+    optional: true
+
+  '@rolldown/binding-linux-arm-gnueabihf@1.2.4':
+    optional: true
+
+  '@rolldown/binding-linux-arm64-gnu@1.2.4':
+    optional: true
+
+  '@rolldown/binding-linux-arm64-musl@1.2.4':
+    optional: true
+
+  '@rolldown/binding-linux-ppc64-gnu@1.2.4':
+    optional: true
+
+  '@rolldown/binding-linux-s390x-gnu@1.2.4':
+    optional: true
+
+  '@rolldown/binding-linux-x64-gnu@1.2.4':
+    optional: true
+
+  '@rolldown/binding-linux-x64-musl@1.2.4':
+    optional: true
+
+  '@rolldown/binding-openharmony-arm64@1.2.4':
+    optional: true
+
+  '@rolldown/binding-win32-arm64-msvc@1.2.4':
+    optional: true
+
+  '@rolldown/binding-win32-x64-msvc@1.2.4':
+    optional: true
+
+  '@rolldown/pluginutils@1.0.1': {}
+
   '@rollup/rollup-android-arm-eabi@4.62.4':
     optional: true
 
@@ -4254,10 +4473,10 @@ snapshots:
       axe-core: 4.13.0
       storybook: 10.5.9(@types/react@19.2.15)(prettier@3.9.6)(react@19.2.8)
 
-  '@storybook/addon-docs@10.5.9(@types/react@19.2.15)(esbuild@0.28.2)(rollup@4.62.4)(storybook@10.5.9(@types/react@19.2.15)(prettier@3.9.6)(react@19.2.8))(vite@7.3.6(@types/node@24.13.3)(sass@1.103.0)(yaml@2.9.0))':
+  '@storybook/addon-docs@10.5.9(@types/react@19.2.15)(esbuild@0.28.2)(rollup@4.62.4)(storybook@10.5.9(@types/react@19.2.15)(prettier@3.9.6)(react@19.2.8))(vite@8.2.1(@types/node@24.13.3)(esbuild@0.28.2)(sass@1.103.0)(yaml@2.9.0))':
     dependencies:
       '@mdx-js/react': 3.1.1(@types/react@19.2.15)(react@19.2.8)
-      '@storybook/csf-plugin': 10.5.9(esbuild@0.28.2)(rollup@4.62.4)(storybook@10.5.9(@types/react@19.2.15)(prettier@3.9.6)(react@19.2.8))(vite@7.3.6(@types/node@24.13.3)(sass@1.103.0)(yaml@2.9.0))
+      '@storybook/csf-plugin': 10.5.9(esbuild@0.28.2)(rollup@4.62.4)(storybook@10.5.9(@types/react@19.2.15)(prettier@3.9.6)(react@19.2.8))(vite@8.2.1(@types/node@24.13.3)(esbuild@0.28.2)(sass@1.103.0)(yaml@2.9.0))
       '@storybook/icons': 2.1.0(react@19.2.8)
       '@storybook/react-dom-shim': 10.5.9(@types/react@19.2.15)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)(storybook@10.5.9(@types/react@19.2.15)(prettier@3.9.6)(react@19.2.8))
       react: 19.2.8
@@ -4273,11 +4492,11 @@ snapshots:
       - vite
       - webpack
 
-  '@storybook/addon-svelte-csf@5.1.2(@storybook/svelte@10.5.9(storybook@10.5.9(@types/react@19.2.15)(prettier@3.9.6)(react@19.2.8))(svelte@5.56.9(@typescript-eslint/types@8.67.0)))(@sveltejs/vite-plugin-svelte@6.2.4(svelte@5.56.9(@typescript-eslint/types@8.67.0))(vite@7.3.6(@types/node@24.13.3)(sass@1.103.0)(yaml@2.9.0)))(storybook@10.5.9(@types/react@19.2.15)(prettier@3.9.6)(react@19.2.8))(svelte@5.56.9(@typescript-eslint/types@8.67.0))(vite@7.3.6(@types/node@24.13.3)(sass@1.103.0)(yaml@2.9.0))':
+  '@storybook/addon-svelte-csf@5.1.2(@storybook/svelte@10.5.9(storybook@10.5.9(@types/react@19.2.15)(prettier@3.9.6)(react@19.2.8))(svelte@5.56.9(@typescript-eslint/types@8.67.0)))(@sveltejs/vite-plugin-svelte@7.3.0(svelte@5.56.9(@typescript-eslint/types@8.67.0))(vite@8.2.1(@types/node@24.13.3)(esbuild@0.28.2)(sass@1.103.0)(yaml@2.9.0)))(storybook@10.5.9(@types/react@19.2.15)(prettier@3.9.6)(react@19.2.8))(svelte@5.56.9(@typescript-eslint/types@8.67.0))(vite@8.2.1(@types/node@24.13.3)(esbuild@0.28.2)(sass@1.103.0)(yaml@2.9.0))':
     dependencies:
       '@storybook/csf': 0.1.13
       '@storybook/svelte': 10.5.9(storybook@10.5.9(@types/react@19.2.15)(prettier@3.9.6)(react@19.2.8))(svelte@5.56.9(@typescript-eslint/types@8.67.0))
-      '@sveltejs/vite-plugin-svelte': 6.2.4(svelte@5.56.9(@typescript-eslint/types@8.67.0))(vite@7.3.6(@types/node@24.13.3)(sass@1.103.0)(yaml@2.9.0))
+      '@sveltejs/vite-plugin-svelte': 7.3.0(svelte@5.56.9(@typescript-eslint/types@8.67.0))(vite@8.2.1(@types/node@24.13.3)(esbuild@0.28.2)(sass@1.103.0)(yaml@2.9.0))
       dedent: 1.7.2
       es-toolkit: 1.51.0
       esrap: 1.4.9
@@ -4285,7 +4504,7 @@ snapshots:
       storybook: 10.5.9(@types/react@19.2.15)(prettier@3.9.6)(react@19.2.8)
       svelte: 5.56.9(@typescript-eslint/types@8.67.0)
       svelte-ast-print: 0.4.2(svelte@5.56.9(@typescript-eslint/types@8.67.0))
-      vite: 7.3.6(@types/node@24.13.3)(sass@1.103.0)(yaml@2.9.0)
+      vite: 8.2.1(@types/node@24.13.3)(esbuild@0.28.2)(sass@1.103.0)(yaml@2.9.0)
       zimmerframe: 1.1.4
     transitivePeerDependencies:
       - babel-plugin-macros
@@ -4301,32 +4520,32 @@ snapshots:
       '@storybook/icons': 2.1.0(react@19.2.8)
       storybook: 10.5.9(@types/react@19.2.15)(prettier@3.9.6)(react@19.2.8)
     optionalDependencies:
-      '@vitest/browser': 4.1.11(vite@7.3.6(@types/node@24.13.3)(sass@1.103.0)(yaml@2.9.0))(vitest@4.1.11)
-      '@vitest/browser-playwright': 4.1.11(playwright@1.62.1)(vite@7.3.6(@types/node@24.13.3)(sass@1.103.0)(yaml@2.9.0))(vitest@4.1.11)
+      '@vitest/browser': 4.1.11(vite@8.2.1(@types/node@24.13.3)(esbuild@0.28.2)(sass@1.103.0)(yaml@2.9.0))(vitest@4.1.11)
+      '@vitest/browser-playwright': 4.1.11(playwright@1.62.1)(vite@8.2.1(@types/node@24.13.3)(esbuild@0.28.2)(sass@1.103.0)(yaml@2.9.0))(vitest@4.1.11)
       '@vitest/runner': 4.1.11
-      vitest: 4.1.11(@types/node@24.13.3)(@vitest/browser-playwright@4.1.11)(@vitest/coverage-v8@4.1.11)(vite@7.3.6(@types/node@24.13.3)(sass@1.103.0)(yaml@2.9.0))
+      vitest: 4.1.11(@types/node@24.13.3)(@vitest/browser-playwright@4.1.11)(@vitest/coverage-v8@4.1.11)(vite@8.2.1(@types/node@24.13.3)(esbuild@0.28.2)(sass@1.103.0)(yaml@2.9.0))
     transitivePeerDependencies:
       - react
 
-  '@storybook/builder-vite@10.5.9(esbuild@0.28.2)(rollup@4.62.4)(storybook@10.5.9(@types/react@19.2.15)(prettier@3.9.6)(react@19.2.8))(vite@7.3.6(@types/node@24.13.3)(sass@1.103.0)(yaml@2.9.0))':
+  '@storybook/builder-vite@10.5.9(esbuild@0.28.2)(rollup@4.62.4)(storybook@10.5.9(@types/react@19.2.15)(prettier@3.9.6)(react@19.2.8))(vite@8.2.1(@types/node@24.13.3)(esbuild@0.28.2)(sass@1.103.0)(yaml@2.9.0))':
     dependencies:
-      '@storybook/csf-plugin': 10.5.9(esbuild@0.28.2)(rollup@4.62.4)(storybook@10.5.9(@types/react@19.2.15)(prettier@3.9.6)(react@19.2.8))(vite@7.3.6(@types/node@24.13.3)(sass@1.103.0)(yaml@2.9.0))
+      '@storybook/csf-plugin': 10.5.9(esbuild@0.28.2)(rollup@4.62.4)(storybook@10.5.9(@types/react@19.2.15)(prettier@3.9.6)(react@19.2.8))(vite@8.2.1(@types/node@24.13.3)(esbuild@0.28.2)(sass@1.103.0)(yaml@2.9.0))
       storybook: 10.5.9(@types/react@19.2.15)(prettier@3.9.6)(react@19.2.8)
       ts-dedent: 2.3.0
-      vite: 7.3.6(@types/node@24.13.3)(sass@1.103.0)(yaml@2.9.0)
+      vite: 8.2.1(@types/node@24.13.3)(esbuild@0.28.2)(sass@1.103.0)(yaml@2.9.0)
     transitivePeerDependencies:
       - esbuild
       - rollup
       - webpack
 
-  '@storybook/csf-plugin@10.5.9(esbuild@0.28.2)(rollup@4.62.4)(storybook@10.5.9(@types/react@19.2.15)(prettier@3.9.6)(react@19.2.8))(vite@7.3.6(@types/node@24.13.3)(sass@1.103.0)(yaml@2.9.0))':
+  '@storybook/csf-plugin@10.5.9(esbuild@0.28.2)(rollup@4.62.4)(storybook@10.5.9(@types/react@19.2.15)(prettier@3.9.6)(react@19.2.8))(vite@8.2.1(@types/node@24.13.3)(esbuild@0.28.2)(sass@1.103.0)(yaml@2.9.0))':
     dependencies:
       storybook: 10.5.9(@types/react@19.2.15)(prettier@3.9.6)(react@19.2.8)
       unplugin: 2.3.11
     optionalDependencies:
       esbuild: 0.28.2
       rollup: 4.62.4
-      vite: 7.3.6(@types/node@24.13.3)(sass@1.103.0)(yaml@2.9.0)
+      vite: 8.2.1(@types/node@24.13.3)(esbuild@0.28.2)(sass@1.103.0)(yaml@2.9.0)
 
   '@storybook/csf@0.1.13':
     dependencies:
@@ -4346,17 +4565,17 @@ snapshots:
     optionalDependencies:
       '@types/react': 19.2.15
 
-  '@storybook/svelte-vite@10.5.9(@sveltejs/vite-plugin-svelte@6.2.4(svelte@5.56.9(@typescript-eslint/types@8.67.0))(vite@7.3.6(@types/node@24.13.3)(sass@1.103.0)(yaml@2.9.0)))(esbuild@0.28.2)(rollup@4.62.4)(storybook@10.5.9(@types/react@19.2.15)(prettier@3.9.6)(react@19.2.8))(svelte@5.56.9(@typescript-eslint/types@8.67.0))(vite@7.3.6(@types/node@24.13.3)(sass@1.103.0)(yaml@2.9.0))':
+  '@storybook/svelte-vite@10.5.9(@sveltejs/vite-plugin-svelte@7.3.0(svelte@5.56.9(@typescript-eslint/types@8.67.0))(vite@8.2.1(@types/node@24.13.3)(esbuild@0.28.2)(sass@1.103.0)(yaml@2.9.0)))(esbuild@0.28.2)(rollup@4.62.4)(storybook@10.5.9(@types/react@19.2.15)(prettier@3.9.6)(react@19.2.8))(svelte@5.56.9(@typescript-eslint/types@8.67.0))(vite@8.2.1(@types/node@24.13.3)(esbuild@0.28.2)(sass@1.103.0)(yaml@2.9.0))':
     dependencies:
-      '@storybook/builder-vite': 10.5.9(esbuild@0.28.2)(rollup@4.62.4)(storybook@10.5.9(@types/react@19.2.15)(prettier@3.9.6)(react@19.2.8))(vite@7.3.6(@types/node@24.13.3)(sass@1.103.0)(yaml@2.9.0))
+      '@storybook/builder-vite': 10.5.9(esbuild@0.28.2)(rollup@4.62.4)(storybook@10.5.9(@types/react@19.2.15)(prettier@3.9.6)(react@19.2.8))(vite@8.2.1(@types/node@24.13.3)(esbuild@0.28.2)(sass@1.103.0)(yaml@2.9.0))
       '@storybook/svelte': 10.5.9(storybook@10.5.9(@types/react@19.2.15)(prettier@3.9.6)(react@19.2.8))(svelte@5.56.9(@typescript-eslint/types@8.67.0))
-      '@sveltejs/vite-plugin-svelte': 6.2.4(svelte@5.56.9(@typescript-eslint/types@8.67.0))(vite@7.3.6(@types/node@24.13.3)(sass@1.103.0)(yaml@2.9.0))
+      '@sveltejs/vite-plugin-svelte': 7.3.0(svelte@5.56.9(@typescript-eslint/types@8.67.0))(vite@8.2.1(@types/node@24.13.3)(esbuild@0.28.2)(sass@1.103.0)(yaml@2.9.0))
       magic-string: 0.30.21
       storybook: 10.5.9(@types/react@19.2.15)(prettier@3.9.6)(react@19.2.8)
       svelte: 5.56.9(@typescript-eslint/types@8.67.0)
       svelte2tsx: 0.7.61(svelte@5.56.9(@typescript-eslint/types@8.67.0))(typescript@5.9.3)
       typescript: 5.9.3
-      vite: 7.3.6(@types/node@24.13.3)(sass@1.103.0)(yaml@2.9.0)
+      vite: 8.2.1(@types/node@24.13.3)(esbuild@0.28.2)(sass@1.103.0)(yaml@2.9.0)
     transitivePeerDependencies:
       - esbuild
       - rollup
@@ -4375,22 +4594,14 @@ snapshots:
 
   '@sveltejs/load-config@0.2.3': {}
 
-  '@sveltejs/vite-plugin-svelte-inspector@5.0.2(@sveltejs/vite-plugin-svelte@6.2.4(svelte@5.56.9(@typescript-eslint/types@8.67.0))(vite@7.3.6(@types/node@24.13.3)(sass@1.103.0)(yaml@2.9.0)))(svelte@5.56.9(@typescript-eslint/types@8.67.0))(vite@7.3.6(@types/node@24.13.3)(sass@1.103.0)(yaml@2.9.0))':
+  '@sveltejs/vite-plugin-svelte@7.3.0(svelte@5.56.9(@typescript-eslint/types@8.67.0))(vite@8.2.1(@types/node@24.13.3)(esbuild@0.28.2)(sass@1.103.0)(yaml@2.9.0))':
     dependencies:
-      '@sveltejs/vite-plugin-svelte': 6.2.4(svelte@5.56.9(@typescript-eslint/types@8.67.0))(vite@7.3.6(@types/node@24.13.3)(sass@1.103.0)(yaml@2.9.0))
-      obug: 2.1.4
-      svelte: 5.56.9(@typescript-eslint/types@8.67.0)
-      vite: 7.3.6(@types/node@24.13.3)(sass@1.103.0)(yaml@2.9.0)
-
-  '@sveltejs/vite-plugin-svelte@6.2.4(svelte@5.56.9(@typescript-eslint/types@8.67.0))(vite@7.3.6(@types/node@24.13.3)(sass@1.103.0)(yaml@2.9.0))':
-    dependencies:
-      '@sveltejs/vite-plugin-svelte-inspector': 5.0.2(@sveltejs/vite-plugin-svelte@6.2.4(svelte@5.56.9(@typescript-eslint/types@8.67.0))(vite@7.3.6(@types/node@24.13.3)(sass@1.103.0)(yaml@2.9.0)))(svelte@5.56.9(@typescript-eslint/types@8.67.0))(vite@7.3.6(@types/node@24.13.3)(sass@1.103.0)(yaml@2.9.0))
       deepmerge: 4.3.1
-      magic-string: 0.30.21
+      magic-string: 1.2.0
       obug: 2.1.4
       svelte: 5.56.9(@typescript-eslint/types@8.67.0)
-      vite: 7.3.6(@types/node@24.13.3)(sass@1.103.0)(yaml@2.9.0)
-      vitefu: 1.1.3(vite@7.3.6(@types/node@24.13.3)(sass@1.103.0)(yaml@2.9.0))
+      vite: 8.2.1(@types/node@24.13.3)(esbuild@0.28.2)(sass@1.103.0)(yaml@2.9.0)
+      vitefu: 1.1.3(vite@8.2.1(@types/node@24.13.3)(esbuild@0.28.2)(sass@1.103.0)(yaml@2.9.0))
 
   '@testing-library/dom@10.4.1':
     dependencies:
@@ -4422,20 +4633,20 @@ snapshots:
       picocolors: 1.1.1
       redent: 3.0.0
     optionalDependencies:
-      vitest: 4.1.11(@types/node@24.13.3)(@vitest/browser-playwright@4.1.11)(@vitest/coverage-v8@4.1.11)(vite@7.3.6(@types/node@24.13.3)(sass@1.103.0)(yaml@2.9.0))
+      vitest: 4.1.11(@types/node@24.13.3)(@vitest/browser-playwright@4.1.11)(@vitest/coverage-v8@4.1.11)(vite@8.2.1(@types/node@24.13.3)(esbuild@0.28.2)(sass@1.103.0)(yaml@2.9.0))
 
   '@testing-library/svelte-core@1.1.3(svelte@5.56.9(@typescript-eslint/types@8.67.0))':
     dependencies:
       svelte: 5.56.9(@typescript-eslint/types@8.67.0)
 
-  '@testing-library/svelte@5.4.2(svelte@5.56.9(@typescript-eslint/types@8.67.0))(vite@7.3.6(@types/node@24.13.3)(sass@1.103.0)(yaml@2.9.0))(vitest@4.1.11)':
+  '@testing-library/svelte@5.4.2(svelte@5.56.9(@typescript-eslint/types@8.67.0))(vite@8.2.1(@types/node@24.13.3)(esbuild@0.28.2)(sass@1.103.0)(yaml@2.9.0))(vitest@4.1.11)':
     dependencies:
       '@testing-library/dom': 10.4.1
       '@testing-library/svelte-core': 1.1.3(svelte@5.56.9(@typescript-eslint/types@8.67.0))
       svelte: 5.56.9(@typescript-eslint/types@8.67.0)
     optionalDependencies:
-      vite: 7.3.6(@types/node@24.13.3)(sass@1.103.0)(yaml@2.9.0)
-      vitest: 4.1.11(@types/node@24.13.3)(@vitest/browser-playwright@4.1.11)(@vitest/coverage-v8@4.1.11)(vite@7.3.6(@types/node@24.13.3)(sass@1.103.0)(yaml@2.9.0))
+      vite: 8.2.1(@types/node@24.13.3)(esbuild@0.28.2)(sass@1.103.0)(yaml@2.9.0)
+      vitest: 4.1.11(@types/node@24.13.3)(@vitest/browser-playwright@4.1.11)(@vitest/coverage-v8@4.1.11)(vite@8.2.1(@types/node@24.13.3)(esbuild@0.28.2)(sass@1.103.0)(yaml@2.9.0))
 
   '@testing-library/user-event@14.6.4(@testing-library/dom@10.4.1)':
     dependencies:
@@ -4564,29 +4775,29 @@ snapshots:
       '@typescript-eslint/types': 8.67.0
       eslint-visitor-keys: 5.0.1
 
-  '@vitest/browser-playwright@4.1.11(playwright@1.62.1)(vite@7.3.6(@types/node@24.13.3)(sass@1.103.0)(yaml@2.9.0))(vitest@4.1.11)':
+  '@vitest/browser-playwright@4.1.11(playwright@1.62.1)(vite@8.2.1(@types/node@24.13.3)(esbuild@0.28.2)(sass@1.103.0)(yaml@2.9.0))(vitest@4.1.11)':
     dependencies:
-      '@vitest/browser': 4.1.11(vite@7.3.6(@types/node@24.13.3)(sass@1.103.0)(yaml@2.9.0))(vitest@4.1.11)
-      '@vitest/mocker': 4.1.11(vite@7.3.6(@types/node@24.13.3)(sass@1.103.0)(yaml@2.9.0))
+      '@vitest/browser': 4.1.11(vite@8.2.1(@types/node@24.13.3)(esbuild@0.28.2)(sass@1.103.0)(yaml@2.9.0))(vitest@4.1.11)
+      '@vitest/mocker': 4.1.11(vite@8.2.1(@types/node@24.13.3)(esbuild@0.28.2)(sass@1.103.0)(yaml@2.9.0))
       playwright: 1.62.1
       tinyrainbow: 3.1.1
-      vitest: 4.1.11(@types/node@24.13.3)(@vitest/browser-playwright@4.1.11)(@vitest/coverage-v8@4.1.11)(vite@7.3.6(@types/node@24.13.3)(sass@1.103.0)(yaml@2.9.0))
+      vitest: 4.1.11(@types/node@24.13.3)(@vitest/browser-playwright@4.1.11)(@vitest/coverage-v8@4.1.11)(vite@8.2.1(@types/node@24.13.3)(esbuild@0.28.2)(sass@1.103.0)(yaml@2.9.0))
     transitivePeerDependencies:
       - bufferutil
       - msw
       - utf-8-validate
       - vite
 
-  '@vitest/browser@4.1.11(vite@7.3.6(@types/node@24.13.3)(sass@1.103.0)(yaml@2.9.0))(vitest@4.1.11)':
+  '@vitest/browser@4.1.11(vite@8.2.1(@types/node@24.13.3)(esbuild@0.28.2)(sass@1.103.0)(yaml@2.9.0))(vitest@4.1.11)':
     dependencies:
       '@blazediff/core': 1.9.1
-      '@vitest/mocker': 4.1.11(vite@7.3.6(@types/node@24.13.3)(sass@1.103.0)(yaml@2.9.0))
+      '@vitest/mocker': 4.1.11(vite@8.2.1(@types/node@24.13.3)(esbuild@0.28.2)(sass@1.103.0)(yaml@2.9.0))
       '@vitest/utils': 4.1.11
       magic-string: 0.30.21
       pngjs: 7.0.0
       sirv: 3.0.2
       tinyrainbow: 3.1.1
-      vitest: 4.1.11(@types/node@24.13.3)(@vitest/browser-playwright@4.1.11)(@vitest/coverage-v8@4.1.11)(vite@7.3.6(@types/node@24.13.3)(sass@1.103.0)(yaml@2.9.0))
+      vitest: 4.1.11(@types/node@24.13.3)(@vitest/browser-playwright@4.1.11)(@vitest/coverage-v8@4.1.11)(vite@8.2.1(@types/node@24.13.3)(esbuild@0.28.2)(sass@1.103.0)(yaml@2.9.0))
       ws: 8.21.3
     transitivePeerDependencies:
       - bufferutil
@@ -4606,9 +4817,9 @@ snapshots:
       obug: 2.1.4
       std-env: 4.2.0
       tinyrainbow: 3.1.1
-      vitest: 4.1.11(@types/node@24.13.3)(@vitest/browser-playwright@4.1.11)(@vitest/coverage-v8@4.1.11)(vite@7.3.6(@types/node@24.13.3)(sass@1.103.0)(yaml@2.9.0))
+      vitest: 4.1.11(@types/node@24.13.3)(@vitest/browser-playwright@4.1.11)(@vitest/coverage-v8@4.1.11)(vite@8.2.1(@types/node@24.13.3)(esbuild@0.28.2)(sass@1.103.0)(yaml@2.9.0))
     optionalDependencies:
-      '@vitest/browser': 4.1.11(vite@7.3.6(@types/node@24.13.3)(sass@1.103.0)(yaml@2.9.0))(vitest@4.1.11)
+      '@vitest/browser': 4.1.11(vite@8.2.1(@types/node@24.13.3)(esbuild@0.28.2)(sass@1.103.0)(yaml@2.9.0))(vitest@4.1.11)
 
   '@vitest/expect@3.2.4':
     dependencies:
@@ -4627,13 +4838,13 @@ snapshots:
       chai: 6.2.2
       tinyrainbow: 3.1.1
 
-  '@vitest/mocker@4.1.11(vite@7.3.6(@types/node@24.13.3)(sass@1.103.0)(yaml@2.9.0))':
+  '@vitest/mocker@4.1.11(vite@8.2.1(@types/node@24.13.3)(esbuild@0.28.2)(sass@1.103.0)(yaml@2.9.0))':
     dependencies:
       '@vitest/spy': 4.1.11
       estree-walker: 3.0.3
       magic-string: 0.30.21
     optionalDependencies:
-      vite: 7.3.6(@types/node@24.13.3)(sass@1.103.0)(yaml@2.9.0)
+      vite: 8.2.1(@types/node@24.13.3)(esbuild@0.28.2)(sass@1.103.0)(yaml@2.9.0)
 
   '@vitest/pretty-format@3.2.4':
     dependencies:
@@ -5011,8 +5222,7 @@ snapshots:
 
   dequal@2.0.3: {}
 
-  detect-libc@2.1.2:
-    optional: true
+  detect-libc@2.1.2: {}
 
   devalue@5.9.0: {}
 
@@ -5552,6 +5762,55 @@ snapshots:
       prelude-ls: 1.2.1
       type-check: 0.4.0
 
+  lightningcss-android-arm64@1.33.0:
+    optional: true
+
+  lightningcss-darwin-arm64@1.33.0:
+    optional: true
+
+  lightningcss-darwin-x64@1.33.0:
+    optional: true
+
+  lightningcss-freebsd-x64@1.33.0:
+    optional: true
+
+  lightningcss-linux-arm-gnueabihf@1.33.0:
+    optional: true
+
+  lightningcss-linux-arm64-gnu@1.33.0:
+    optional: true
+
+  lightningcss-linux-arm64-musl@1.33.0:
+    optional: true
+
+  lightningcss-linux-x64-gnu@1.33.0:
+    optional: true
+
+  lightningcss-linux-x64-musl@1.33.0:
+    optional: true
+
+  lightningcss-win32-arm64-msvc@1.33.0:
+    optional: true
+
+  lightningcss-win32-x64-msvc@1.33.0:
+    optional: true
+
+  lightningcss@1.33.0:
+    dependencies:
+      detect-libc: 2.1.2
+    optionalDependencies:
+      lightningcss-android-arm64: 1.33.0
+      lightningcss-darwin-arm64: 1.33.0
+      lightningcss-darwin-x64: 1.33.0
+      lightningcss-freebsd-x64: 1.33.0
+      lightningcss-linux-arm-gnueabihf: 1.33.0
+      lightningcss-linux-arm64-gnu: 1.33.0
+      lightningcss-linux-arm64-musl: 1.33.0
+      lightningcss-linux-x64-gnu: 1.33.0
+      lightningcss-linux-x64-musl: 1.33.0
+      lightningcss-win32-arm64-msvc: 1.33.0
+      lightningcss-win32-x64-msvc: 1.33.0
+
   lilconfig@2.1.0: {}
 
   lilconfig@3.1.3: {}
@@ -5579,6 +5838,10 @@ snapshots:
   lz-string@1.5.0: {}
 
   magic-string@0.30.21:
+    dependencies:
+      '@jridgewell/sourcemap-codec': 1.5.5
+
+  magic-string@1.2.0:
     dependencies:
       '@jridgewell/sourcemap-codec': 1.5.5
 
@@ -6054,6 +6317,26 @@ snapshots:
 
   reusify@1.1.0: {}
 
+  rolldown@1.2.4:
+    dependencies:
+      '@oxc-project/types': 0.144.0
+      '@rolldown/pluginutils': 1.0.1
+    optionalDependencies:
+      '@rolldown/binding-android-arm64': 1.2.4
+      '@rolldown/binding-darwin-arm64': 1.2.4
+      '@rolldown/binding-darwin-x64': 1.2.4
+      '@rolldown/binding-freebsd-x64': 1.2.4
+      '@rolldown/binding-linux-arm-gnueabihf': 1.2.4
+      '@rolldown/binding-linux-arm64-gnu': 1.2.4
+      '@rolldown/binding-linux-arm64-musl': 1.2.4
+      '@rolldown/binding-linux-ppc64-gnu': 1.2.4
+      '@rolldown/binding-linux-s390x-gnu': 1.2.4
+      '@rolldown/binding-linux-x64-gnu': 1.2.4
+      '@rolldown/binding-linux-x64-musl': 1.2.4
+      '@rolldown/binding-openharmony-arm64': 1.2.4
+      '@rolldown/binding-win32-arm64-msvc': 1.2.4
+      '@rolldown/binding-win32-x64-msvc': 1.2.4
+
   rollup@4.62.4:
     dependencies:
       '@types/estree': 1.0.9
@@ -6085,6 +6368,7 @@ snapshots:
       '@rollup/rollup-win32-x64-gnu': 4.62.4
       '@rollup/rollup-win32-x64-msvc': 4.62.4
       fsevents: 2.3.3
+    optional: true
 
   run-applescript@7.1.0: {}
 
@@ -6459,28 +6743,28 @@ snapshots:
       is-typed-array: 1.1.15
       which-typed-array: 1.1.22
 
-  vite@7.3.6(@types/node@24.13.3)(sass@1.103.0)(yaml@2.9.0):
+  vite@8.2.1(@types/node@24.13.3)(esbuild@0.28.2)(sass@1.103.0)(yaml@2.9.0):
     dependencies:
-      esbuild: 0.28.2
-      fdir: 6.5.0(picomatch@4.0.5)
+      lightningcss: 1.33.0
       picomatch: 4.0.5
       postcss: 8.5.26
-      rollup: 4.62.4
+      rolldown: 1.2.4
       tinyglobby: 0.2.17
     optionalDependencies:
       '@types/node': 24.13.3
+      esbuild: 0.28.2
       fsevents: 2.3.3
       sass: 1.103.0
       yaml: 2.9.0
 
-  vitefu@1.1.3(vite@7.3.6(@types/node@24.13.3)(sass@1.103.0)(yaml@2.9.0)):
+  vitefu@1.1.3(vite@8.2.1(@types/node@24.13.3)(esbuild@0.28.2)(sass@1.103.0)(yaml@2.9.0)):
     optionalDependencies:
-      vite: 7.3.6(@types/node@24.13.3)(sass@1.103.0)(yaml@2.9.0)
+      vite: 8.2.1(@types/node@24.13.3)(esbuild@0.28.2)(sass@1.103.0)(yaml@2.9.0)
 
-  vitest@4.1.11(@types/node@24.13.3)(@vitest/browser-playwright@4.1.11)(@vitest/coverage-v8@4.1.11)(vite@7.3.6(@types/node@24.13.3)(sass@1.103.0)(yaml@2.9.0)):
+  vitest@4.1.11(@types/node@24.13.3)(@vitest/browser-playwright@4.1.11)(@vitest/coverage-v8@4.1.11)(vite@8.2.1(@types/node@24.13.3)(esbuild@0.28.2)(sass@1.103.0)(yaml@2.9.0)):
     dependencies:
       '@vitest/expect': 4.1.11
-      '@vitest/mocker': 4.1.11(vite@7.3.6(@types/node@24.13.3)(sass@1.103.0)(yaml@2.9.0))
+      '@vitest/mocker': 4.1.11(vite@8.2.1(@types/node@24.13.3)(esbuild@0.28.2)(sass@1.103.0)(yaml@2.9.0))
       '@vitest/pretty-format': 4.1.11
       '@vitest/runner': 4.1.11
       '@vitest/snapshot': 4.1.11
@@ -6497,11 +6781,11 @@ snapshots:
       tinyexec: 1.3.0
       tinyglobby: 0.2.17
       tinyrainbow: 3.1.1
-      vite: 7.3.6(@types/node@24.13.3)(sass@1.103.0)(yaml@2.9.0)
+      vite: 8.2.1(@types/node@24.13.3)(esbuild@0.28.2)(sass@1.103.0)(yaml@2.9.0)
       why-is-node-running: 2.3.0
     optionalDependencies:
       '@types/node': 24.13.3
-      '@vitest/browser-playwright': 4.1.11(playwright@1.62.1)(vite@7.3.6(@types/node@24.13.3)(sass@1.103.0)(yaml@2.9.0))(vitest@4.1.11)
+      '@vitest/browser-playwright': 4.1.11(playwright@1.62.1)(vite@8.2.1(@types/node@24.13.3)(esbuild@0.28.2)(sass@1.103.0)(yaml@2.9.0))(vitest@4.1.11)
       '@vitest/coverage-v8': 4.1.11(@vitest/browser@4.1.11)(vitest@4.1.11)
     transitivePeerDependencies:
       - msw

--- a/tests/outils/injection-nonce.spec.ts
+++ b/tests/outils/injection-nonce.spec.ts
@@ -1,7 +1,7 @@
 import { expect, it, describe } from "vitest";
 import { injecteNonceWebcomponents } from "../../outils/injection-nonce.js";
 
-const codeWebcomponents = `
+const codeFormatVite7 = `
 var WebComponents = function() {
   function createElement(n) {
     return document.createElement(n);
@@ -15,17 +15,60 @@ var WebComponents = function() {
 }({});
 `;
 
+const codeFormatVite8 = `
+var WebComponents = (function(e) {
+  Object.defineProperty(e, Symbol.toStringTag, {value: \`Module\`});
+  function a() {
+    let x = Sn(\`style\`);
+  }
+  function b() {
+    var styleEl = Dr(\`style\`);
+  }
+}({}));
+`;
+
+const codeAvecCreateElement = `
+var WebComponents = function() {
+  function a() {
+    let el = document.createElement(\`style\`);
+  }
+}({});
+`;
+
 describe("L'utilitaire d'injection du nonce (pour les styles des composants Svelte)", () => {
   it("insère la récupération du nonce au début du fichier", () => {
-    const codeAvecNonce = injecteNonceWebcomponents(codeWebcomponents);
+    const codeAvecNonce = injecteNonceWebcomponents(codeFormatVite7);
 
     expect(codeAvecNonce.startsWith("const nonce = document.currentScript?.nonce;\n")).toBe(true);
   });
 
-  it("affecte le nonce a toutes les balises de styles injectées", () => {
-    const codeAvecNonce = injecteNonceWebcomponents(codeWebcomponents);
+  describe("affecte le nonce à toutes les balises de styles injectées", () => {
+    it("avec le format Vite 7 (const + guillemets doubles)", () => {
+      const codeAvecNonce = injecteNonceWebcomponents(codeFormatVite7);
 
-    expect(codeAvecNonce).toContain(' const x = createElement("style");x.nonce=nonce;');
-    expect(codeAvecNonce).toContain(' const styleEl = Dr("style");styleEl.nonce=nonce;');
+      expect(codeAvecNonce).toContain(' const x = createElement("style");x.nonce=nonce;');
+      expect(codeAvecNonce).toContain(' const styleEl = Dr("style");styleEl.nonce=nonce;');
+    });
+
+    it("avec le format Vite 8 (let/var + backticks)", () => {
+      const codeAvecNonce = injecteNonceWebcomponents(codeFormatVite8);
+
+      expect(codeAvecNonce).toContain("let x = Sn(`style`);x.nonce=nonce;");
+      expect(codeAvecNonce).toContain("var styleEl = Dr(`style`);styleEl.nonce=nonce;");
+    });
+
+    it("avec document.createElement et backticks", () => {
+      const codeAvecNonce = injecteNonceWebcomponents(codeAvecCreateElement);
+
+      expect(codeAvecNonce).toContain("let el = document.createElement(`style`);el.nonce=nonce;");
+    });
+  });
+
+  it("lève une erreur si aucun pattern de création de <style> n'est trouvé", () => {
+    const codeSansStyle = `var WebComponents = function() { console.log("hello"); }({});`;
+
+    expect(() => injecteNonceWebcomponents(codeSansStyle)).toThrow(
+      "Le plugin injecteNonce n'a trouvé aucun pattern",
+    );
   });
 });

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -1,14 +1,15 @@
 import { storybookTest } from "@storybook/addon-vitest/vitest-plugin";
 import { svelte } from "@sveltejs/vite-plugin-svelte";
 import dotenv from "dotenv";
-import { fileURLToPath } from "node:url";
 import path from "path";
 import { defineConfig } from "vitest/config";
 import { playwright } from "@vitest/browser-playwright";
-import { assetsPath, replaceIconPaths, varEnv, viteScssPreprocessorOptions } from "./outils";
-
-const dirname =
-  typeof __dirname !== "undefined" ? __dirname : path.dirname(fileURLToPath(import.meta.url));
+import {
+  assetsPath,
+  replaceIconPaths,
+  varEnv,
+  viteScssPreprocessorOptions,
+} from "./outils/index.ts";
 
 // On charge manuellement les valeurs d'environnement de la production, car pour une raison qu'on ignore
 // c'est la seule façon de charger Storybook avec nos valeurs
@@ -19,7 +20,7 @@ if (process.env.STORYBOOK_ENV === "production")
 export default defineConfig({
   resolve: {
     alias: {
-      src: path.resolve(__dirname, "src"),
+      src: path.resolve(import.meta.dirname, "src"),
     },
   },
   plugins: [svelte()],
@@ -47,7 +48,7 @@ export default defineConfig({
           // Le plugin exécutera des tests pour les histoires définies dans la configuration de votre Storybook.
           // Voir les options sur le site: https://storybook.js.org/docs/next/writing-tests/integrations/vitest-addon#storybooktest
           storybookTest({
-            configDir: path.join(dirname, ".storybook"),
+            configDir: path.join(import.meta.dirname, ".storybook"),
           }),
         ],
         test: {

--- a/vite.webcomponents.config.ts
+++ b/vite.webcomponents.config.ts
@@ -11,7 +11,7 @@ import {
   replaceIconPaths,
   varEnv,
   viteScssPreprocessorOptions,
-} from "./outils";
+} from "./outils/index.ts";
 
 // Ce fichier permet de build la librairie en mode "WebComponents"
 // En suivant cette issue : https://github.com/sveltejs/kit/issues/10320
@@ -19,7 +19,7 @@ import {
 export default defineConfig({
   build: {
     lib: {
-      entry: path.resolve(__dirname, "src/lib/index.ts"),
+      entry: path.resolve(import.meta.dirname, "src/lib/index.ts"),
       name: "WebComponents",
       fileName: "lab-anssi-ui-kit",
       formats: ["iife"],
@@ -28,8 +28,8 @@ export default defineConfig({
   },
   resolve: {
     alias: {
-      src: path.resolve(__dirname, "src"),
-      $lib: path.resolve(__dirname, "src/lib"),
+      src: path.resolve(import.meta.dirname, "src"),
+      $lib: path.resolve(import.meta.dirname, "src/lib"),
     },
   },
   css: {


### PR DESCRIPTION
## Décrire les changements

Cette PR effectue la montée de version de **Vite** vers la version majeure **Vite 8**.

### Mise à jour des fichiers de configuration
On profite également de cette montée de version pour mettre à jour les fichiers de configuration Vite (`vite.config.ts`, `vite.webcomponents.config.ts`, `.storybook/main.ts`) et les modules utilitaires (`outils/`) qui utilisaient des raccourcis/syntaxes hérités de CommonJS, comme par exemple : 

- `__dirname` au lieu de import.meta.dirname
- des imports sans extension (ex : `"./mon-fichier"` au lieu de `"./mon-fichier.ts"`)
- des imports de répertoire (ex : `"./outils"` au lieu de `"./outils/index.ts"`)

Ces patterns étaient jusqu'ici tolérés par Vite, qui les injectait/résolvait automatiquement. Avec **Vite 8**, un nouveau mode `configLoader: 'native'` est en préparation pour devenir le défaut dans une future version majeure. Ce mode n'assurera plus ces résolutions implicites.

Ces modifications n'ont aucun impact fonctionnel : elles remplacent uniquement les raccourcis par leurs équivalents ESM natifs, conformes au `"type": "module"` du `package.json`.

### Injection du `nonce`
La PR implémente également une mise à jour du code permettant d'injecter le `nonce` dans le build `.iife` en raison du fait que le passage à **Vite 8**, change en partie le format du code de sortie sur lequel se base le script `outils/injection-nonce.ts`.

## Liens complémentaires
- [Vite 8.0 is out!](https://vite.dev/blog/announcing-vite8)
- [Configuring Vite](https://vite.dev/config/#configuring-vite)
- [feat(config): warn features incompatible with native loader in bundle loader](https://github.com/vitejs/vite/pull/22850)
- [Mandatory file extensions](https://nodejs.org/api/esm.html#mandatory-file-extensions)
- [Differences between ES modules and CommonJS](https://nodejs.org/api/esm.html#differences-between-es-modules-and-commonjs)
