### PR TITLE
[RENOVATE] Ajoute une période minimum de publication de 7 jours pour la mise à jour des dépendances

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -10,6 +10,7 @@
   "labels": ["dependencies"],
   "prConcurrentLimit": 5,
   "prHourlyLimit": 10,
+  "minimumReleaseAge": "7 days",
   "packageRules": [
     {
       "description": "Auto-merge les mises à jour patch des devDependencies",


### PR DESCRIPTION
## Décrire les changements

Ajoute une période minimum de publication de 7 jours pour la mise à jour des dépendances

## Autres informations

<!-- Ajoutez ici tout autre commentaire ou toute autre information concernant cette Pull Request. -->
