### PR TITLE
[OUTILLAGE] Consolide la configuration pnpm

### DIFF
--- a/.github/workflows/integration-continue.yml
+++ b/.github/workflows/integration-continue.yml
@@ -52,8 +52,13 @@ jobs:
         with:
           node-version: 24.19.0
 
+      - name: Installe pnpm
+        uses: pnpm/setup@84cb39b217b10273981911c288cd62326dc7c6d2 # v2.0.2
+        with:
+          install: false
+
       - name: Installer les dépendances
-        run: npm install -g "$(jq -r '.packageManager' package.json)" && pnpm install
+        run: pnpm install --frozen-lockfile
 
       - name: Installer Playwright
         run: ./node_modules/.bin/playwright install chromium --with-deps

--- a/.github/workflows/publication-npm.yml
+++ b/.github/workflows/publication-npm.yml
@@ -29,8 +29,13 @@ jobs:
           registry-url: "https://registry.npmjs.org/"
           package-manager-cache: false
 
+      - name: Installe pnpm
+        uses: pnpm/setup@84cb39b217b10273981911c288cd62326dc7c6d2 # v2.0.2
+        with:
+          install: false
+
       - name: Installer les dépendances
-        run: npm install -g "$(jq -r '.packageManager' package.json)" && pnpm install
+        run: pnpm install --frozen-lockfile
 
       - name: Installer Playwright
         run: ./node_modules/.bin/playwright install chromium --with-deps

--- a/.github/workflows/publication-storybook-dev.yml
+++ b/.github/workflows/publication-storybook-dev.yml
@@ -19,8 +19,13 @@ jobs:
         with:
           node-version: 24.19.0
 
+      - name: Installe pnpm
+        uses: pnpm/setup@84cb39b217b10273981911c288cd62326dc7c6d2 # v2.0.2
+        with:
+          install: false
+
       - name: Installer les dépendances
-        run: npm install -g "$(jq -r '.packageManager' package.json)" && pnpm install
+        run: pnpm install --frozen-lockfile
 
       - name: Installer Playwright
         run: ./node_modules/.bin/playwright install chromium --with-deps

--- a/.github/workflows/publication-storybook.yml
+++ b/.github/workflows/publication-storybook.yml
@@ -32,8 +32,13 @@ jobs:
         with:
           node-version: 24.19.0
 
+      - name: Installe pnpm
+        uses: pnpm/setup@84cb39b217b10273981911c288cd62326dc7c6d2 # v2.0.2
+        with:
+          install: false
+
       - name: Installer les dépendances
-        run: npm install -g "$(jq -r '.packageManager' package.json)" && pnpm install
+        run: pnpm install --frozen-lockfile
 
       - name: Installer Playwright
         run: ./node_modules/.bin/playwright install chromium --with-deps

--- a/.github/workflows/test-storybook.yml
+++ b/.github/workflows/test-storybook.yml
@@ -50,8 +50,13 @@ jobs:
         with:
           node-version: 24.19.0
 
+      - name: Installe pnpm
+        uses: pnpm/setup@84cb39b217b10273981911c288cd62326dc7c6d2 # v2.0.2
+        with:
+          install: false
+
       - name: Installer les dépendances
-        run: npm install -g "$(jq -r '.packageManager' package.json)" && pnpm install
+        run: pnpm install --frozen-lockfile
 
       - name: Installer Playwright
         run: ./node_modules/.bin/playwright install chromium --with-deps

--- a/package.json
+++ b/package.json
@@ -10,26 +10,31 @@
     "url": "https://github.com/betagouv/lab-anssi-ui-kit/issues"
   },
   "homepage": "https://github.com/betagouv/lab-anssi-ui-kit#readme",
-  "packageManager": "pnpm@11.24.0",
   "engines": {
     "node": ">=24.18.0"
   },
+  "devEngines": {
+    "packageManager": {
+      "name": "pnpm",
+      "version": "11.24.0",
+      "onFail": "error"
+    }
+  },
   "scripts": {
-    "build": "vite build && npm run build:manifest && npm run prepack",
+    "build": "vite build && pnpm run build:manifest && pnpm run prepack",
     "build:tokens": "node src/tokens/build.config.ts && pnpm prettier -w .storybook/lab-anssi-themes.css",
     "build:webcomponents": "vite -c vite.webcomponents.config.ts build",
     "build:styles:dsfr": "sass src/lib/styles/dsfr-variables.scss dist/assets/dsfr-variables.css -I node_modules -I node_modules/@gouvfr/dsfr --no-source-map",
     "build:manifest": "node scripts/generate-ui-manifest.mjs",
     "prepare": "husky",
-    "prepack": "npm run build:webcomponents && npm run copy:icons && publint",
+    "prepack": "pnpm run build:webcomponents && pnpm run copy:icons && publint",
     "test": "vitest run",
     "storybook:dev": "STORYBOOK_ENV=development storybook dev -p 6006",
     "storybook:build": "STORYBOOK_ENV=production storybook build",
     "storybook:build-dev": "STORYBOOK_ENV=development storybook build",
     "storybook:test": "STORYBOOK_ENV=production pnpm run test-storybook",
     "test-storybook": "vitest --project=storybook",
-    "copy:icons": "cp -r node_modules/@gouvfr/dsfr/dist/icons/* src/lib/assets/icones/dsfr && cp -r src/lib/assets/ dist/",
-    "preinstall": "npx only-allow@1.2.2 pnpm"
+    "copy:icons": "cp -r node_modules/@gouvfr/dsfr/dist/icons/* src/lib/assets/icones/dsfr && cp -r src/lib/assets/ dist/"
   },
   "files": [
     "dist",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1,3 +1,202 @@
+---
+lockfileVersion: '9.0'
+
+importers:
+
+  .:
+    configDependencies: {}
+    packageManagerDependencies:
+      '@pnpm/exe':
+        specifier: 11.24.0
+        version: 11.24.0
+      pnpm:
+        specifier: 11.24.0
+        version: 11.24.0
+
+packages:
+
+  '@pnpm/exe@11.24.0':
+    resolution: {integrity: sha512-yCZWlhNOB3GS0I2uZC/CggwGZ+TLVLbOuBcMbVWXKFYJOg/0gnQw8eIN6YZLA+eeSvfHEvS79IDdbwu5CMQR0g==}
+    hasBin: true
+
+  '@pnpm/linux-arm64@11.24.0':
+    resolution: {integrity: sha512-wgAF82SnMfWU8/xb0VLszKJYqL+MDHMMGz42s4jW+GIFUGYna/xG5VXUxgcv2FaZhJ2GbyZVUf2f/UJs6nb+zA==}
+    cpu: [arm64]
+    os: [linux]
+
+  '@pnpm/linux-x64@11.24.0':
+    resolution: {integrity: sha512-94e4GRvFB5hEwr9subLHLF2q3+DduKFPh2FE0+F7fgqt1Bs86gDxjJ7bbQCpTX2X4j6cUTA5Hc0HFzMz4xKnaA==}
+    cpu: [x64]
+    os: [linux]
+
+  '@pnpm/linuxstatic-arm64@11.24.0':
+    resolution: {integrity: sha512-1Vwk+M5fzjg364SDZfrtaZfthsy1THS9eSdH7dpBaG0l3HbLusQrh8labRlpMmK8KyQXcI1FvYLzPZVuAGGPng==}
+    cpu: [arm64]
+    os: [linux]
+    libc: [musl]
+
+  '@pnpm/linuxstatic-x64@11.24.0':
+    resolution: {integrity: sha512-oyPChWYdJpJMDnwtCFNzupD+GEO4G6DDMARuZfBrCUgqRm1h2KDcVCqk9IbfFBfxWdK+bVHJpA9Qp3nlL6/thw==}
+    cpu: [x64]
+    os: [linux]
+    libc: [musl]
+
+  '@pnpm/macos-arm64@11.24.0':
+    resolution: {integrity: sha512-nBzaOkR4D7HiuJRwlpk1aqaA/Wai11/zuCZjH5ZUe6fq86UWsqME0u3/F5K0j7yN8X2h7iKiApAaVmbfYMIc6A==}
+    cpu: [arm64]
+    os: [darwin]
+
+  '@pnpm/win-arm64@11.24.0':
+    resolution: {integrity: sha512-ECLc0U/5cnXRkBrpO/dW+x1Y+a2CCqS4l171H7+YOQNcSaCAWlezP3YNvuO+5awwGWHIW7KEXbBruu5n50zVuA==}
+    cpu: [arm64]
+    os: [win32]
+
+  '@pnpm/win-x64@11.24.0':
+    resolution: {integrity: sha512-2wgDrs2SiyBoU6Yw1A8QLLqBABWHwuMMQOU85k7ZMut/W94u/oizrDQiyfJyW9XzYCz4Dn2iw7OHx+3R2x7mEQ==}
+    cpu: [x64]
+    os: [win32]
+
+  '@reflink/reflink-darwin-arm64@0.1.19':
+    resolution: {integrity: sha512-ruy44Lpepdk1FqDz38vExBY/PVUsjxZA+chd9wozjUH9JjuDT/HEaQYA6wYN9mf041l0yLVar6BCZuWABJvHSA==}
+    engines: {node: '>= 10'}
+    cpu: [arm64]
+    os: [darwin]
+
+  '@reflink/reflink-darwin-x64@0.1.19':
+    resolution: {integrity: sha512-By85MSWrMZa+c26TcnAy8SDk0sTUkYlNnwknSchkhHpGXOtjNDUOxJE9oByBnGbeuIE1PiQsxDG3Ud+IVV9yuA==}
+    engines: {node: '>= 10'}
+    cpu: [x64]
+    os: [darwin]
+
+  '@reflink/reflink-linux-arm64-gnu@0.1.19':
+    resolution: {integrity: sha512-7P+er8+rP9iNeN+bfmccM4hTAaLP6PQJPKWSA4iSk2bNvo6KU6RyPgYeHxXmzNKzPVRcypZQTpFgstHam6maVg==}
+    engines: {node: '>= 10'}
+    cpu: [arm64]
+    os: [linux]
+    libc: [glibc]
+
+  '@reflink/reflink-linux-arm64-musl@0.1.19':
+    resolution: {integrity: sha512-37iO/Dp6m5DDaC2sf3zPtx/hl9FV3Xze4xoYidrxxS9bgP3S8ALroxRK6xBG/1TtfXKTvolvp+IjrUU6ujIGmA==}
+    engines: {node: '>= 10'}
+    cpu: [arm64]
+    os: [linux]
+    libc: [musl]
+
+  '@reflink/reflink-linux-x64-gnu@0.1.19':
+    resolution: {integrity: sha512-jbI8jvuYCaA3MVUdu8vLoLAFqC+iNMpiSuLbxlAgg7x3K5bsS8nOpTRnkLF7vISJ+rVR8W+7ThXlXlUQ93ulkw==}
+    engines: {node: '>= 10'}
+    cpu: [x64]
+    os: [linux]
+    libc: [glibc]
+
+  '@reflink/reflink-linux-x64-musl@0.1.19':
+    resolution: {integrity: sha512-e9FBWDe+lv7QKAwtKOt6A2W/fyy/aEEfr0g6j/hWzvQcrzHCsz07BNQYlNOjTfeytrtLU7k449H1PI95jA4OjQ==}
+    engines: {node: '>= 10'}
+    cpu: [x64]
+    os: [linux]
+    libc: [musl]
+
+  '@reflink/reflink-win32-arm64-msvc@0.1.19':
+    resolution: {integrity: sha512-09PxnVIQcd+UOn4WAW73WU6PXL7DwGS6wPlkMhMg2zlHHG65F3vHepOw06HFCq+N42qkaNAc8AKIabWvtk6cIQ==}
+    engines: {node: '>= 10'}
+    cpu: [arm64]
+    os: [win32]
+
+  '@reflink/reflink-win32-x64-msvc@0.1.19':
+    resolution: {integrity: sha512-E//yT4ni2SyhwP8JRjVGWr3cbnhWDiPLgnQ66qqaanjjnMiu3O/2tjCPQXlcGc/DEYofpDc9fvhv6tALQsMV9w==}
+    engines: {node: '>= 10'}
+    cpu: [x64]
+    os: [win32]
+
+  '@reflink/reflink@0.1.19':
+    resolution: {integrity: sha512-DmCG8GzysnCZ15bres3N5AHCmwBwYgp0As6xjhQ47rAUTUXxJiK+lLUxaGsX3hd/30qUpVElh05PbGuxRPgJwA==}
+    engines: {node: '>= 10'}
+
+  detect-libc@2.1.2:
+    resolution: {integrity: sha512-Btj2BOOO83o3WyH59e8MgXsxEQVcarkUOpEYrubB0urwnN10yQ364rsiByU11nZlqWYZm05i/of7io4mzihBtQ==}
+    engines: {node: '>=8'}
+
+  pnpm@11.24.0:
+    resolution: {integrity: sha512-vSfjRel23LC+C3oSKCF7BJqBfiGx81XJDb59xGZxiVqLwebQbCRVRQXqk+oLRfSJon7Bv7yN5qlln8oPFvoAAA==}
+    engines: {node: '>=22.13'}
+    hasBin: true
+
+snapshots:
+
+  '@pnpm/exe@11.24.0':
+    dependencies:
+      '@reflink/reflink': 0.1.19
+      detect-libc: 2.1.2
+    optionalDependencies:
+      '@pnpm/linux-arm64': 11.24.0
+      '@pnpm/linux-x64': 11.24.0
+      '@pnpm/linuxstatic-arm64': 11.24.0
+      '@pnpm/linuxstatic-x64': 11.24.0
+      '@pnpm/macos-arm64': 11.24.0
+      '@pnpm/win-arm64': 11.24.0
+      '@pnpm/win-x64': 11.24.0
+
+  '@pnpm/linux-arm64@11.24.0':
+    optional: true
+
+  '@pnpm/linux-x64@11.24.0':
+    optional: true
+
+  '@pnpm/linuxstatic-arm64@11.24.0':
+    optional: true
+
+  '@pnpm/linuxstatic-x64@11.24.0':
+    optional: true
+
+  '@pnpm/macos-arm64@11.24.0':
+    optional: true
+
+  '@pnpm/win-arm64@11.24.0':
+    optional: true
+
+  '@pnpm/win-x64@11.24.0':
+    optional: true
+
+  '@reflink/reflink-darwin-arm64@0.1.19':
+    optional: true
+
+  '@reflink/reflink-darwin-x64@0.1.19':
+    optional: true
+
+  '@reflink/reflink-linux-arm64-gnu@0.1.19':
+    optional: true
+
+  '@reflink/reflink-linux-arm64-musl@0.1.19':
+    optional: true
+
+  '@reflink/reflink-linux-x64-gnu@0.1.19':
+    optional: true
+
+  '@reflink/reflink-linux-x64-musl@0.1.19':
+    optional: true
+
+  '@reflink/reflink-win32-arm64-msvc@0.1.19':
+    optional: true
+
+  '@reflink/reflink-win32-x64-msvc@0.1.19':
+    optional: true
+
+  '@reflink/reflink@0.1.19':
+    optionalDependencies:
+      '@reflink/reflink-darwin-arm64': 0.1.19
+      '@reflink/reflink-darwin-x64': 0.1.19
+      '@reflink/reflink-linux-arm64-gnu': 0.1.19
+      '@reflink/reflink-linux-arm64-musl': 0.1.19
+      '@reflink/reflink-linux-x64-gnu': 0.1.19
+      '@reflink/reflink-linux-x64-musl': 0.1.19
+      '@reflink/reflink-win32-arm64-msvc': 0.1.19
+      '@reflink/reflink-win32-x64-msvc': 0.1.19
+
+  detect-libc@2.1.2: {}
+
+  pnpm@11.24.0: {}
+
+---
 lockfileVersion: '9.0'
 
 settings:


### PR DESCRIPTION
## Décrire les changements

Cette PR remplace `only-allow` par la configuration native `devEngines.packageManager`.

- Déclare pnpm `11.24.0` via `devEngines.packageManager`.
- Configure `onFail: "error"` afin de refuser les autres gestionnaires de paquets.
- Supprime le script `preinstall` utilisant `npx only-allow`.
- Configure les workflows avec `pnpm/setup@v2.0.2`, épinglé par SHA.
- Installe les dépendances avec `pnpm install --frozen-lockfile` dans les workflows.
- Met à jour `pnpm-lock.yaml` avec les dépendances nécessaires à la gestion de la version de pnpm.

## Cette PR introduit-elle un "breaking change" ?

- [ ] Yes
- [x] No

## Autres informations

Validations effectuées :

- L’installation avec `--frozen-lockfile` réussit avec pnpm `11.24.0`.
- Les 21 tests unitaires réussissent.
- npm `11.17.0` est correctement refusé avec `EBADDEVENGINES`.
