### PR TITLE
[STYLE] Remplace les imports CSS DSFR par @use

### DIFF
--- a/src/lib/composants/Reactions.svelte
+++ b/src/lib/composants/Reactions.svelte
@@ -310,9 +310,9 @@
 </div>
 
 <style lang="scss">
+  @use "@gouvfr/dsfr/dist/component/tooltip/tooltip.main.min.css";
   @import "@gouvfr/dsfr/src/dsfr/core/index";
   @import "@gouvfr/dsfr/src/dsfr/core/style/placement/module";
-  @import "@gouvfr/dsfr/dist/component/tooltip/tooltip.main.min.css";
 
   .lab-anssi-reactions {
     box-sizing: border-box;

--- a/src/lib/dsfr/DsfrAlert.svelte
+++ b/src/lib/dsfr/DsfrAlert.svelte
@@ -87,6 +87,9 @@
 <style lang="scss">
   // DSFR Core styles
   @use "src/lib/styles/mixins-dsfr.scss" as *;
+  // DSFR Component styles
+  @use "@gouvfr/dsfr/dist/component/alert/alert.main.css";
+  @use "@gouvfr/dsfr/dist/component/button/button.main.css";
   @import "@gouvfr/dsfr/src/dsfr/core/index";
   @import "@gouvfr/dsfr/src/dsfr/core/style/action/module/link";
   @import "@gouvfr/dsfr/src/dsfr/core/style/action/module/button";
@@ -99,10 +102,6 @@
   @import "@gouvfr/dsfr/src/dsfr/core/style/typography/module/paragraph";
   @import "@gouvfr/dsfr/src/dsfr/core/style/scheme";
   @include _core-scheme();
-  // DSFR Component styles
-  @import "@gouvfr/dsfr/dist/component/alert/alert.main.css";
-  @import "@gouvfr/dsfr/dist/component/button/button.main.css";
-
   @include set-shadow-host();
   @include set-dsfr-sizing("alert");
 </style>

--- a/src/lib/dsfr/DsfrBadge.svelte
+++ b/src/lib/dsfr/DsfrBadge.svelte
@@ -70,12 +70,11 @@
 <style lang="scss">
   // DSFR Core styles
   @use "src/lib/styles/mixins-dsfr.scss" as *;
+  // DSFR Component styles
+  @use "@gouvfr/dsfr/dist/component/badge/badge.main.css";
   @import "@gouvfr/dsfr/src/dsfr/core/index";
   @import "@gouvfr/dsfr/src/dsfr/core/style/typography/module/paragraph";
   @import "@gouvfr/dsfr/src/dsfr/core/style/display/module/ellipsis";
-  // DSFR Component styles
-  @import "@gouvfr/dsfr/dist/component/badge/badge.main.css";
-
   @include set-shadow-host("inline-flex");
   @include set-dsfr-sizing("badge");
 </style>

--- a/src/lib/dsfr/DsfrBadgesGroup.svelte
+++ b/src/lib/dsfr/DsfrBadgesGroup.svelte
@@ -71,13 +71,12 @@
 <style lang="scss">
   // DSFR Core styles
   @use "src/lib/styles/mixins-dsfr.scss" as *;
+  // DSFR Component styles
+  @use "@gouvfr/dsfr/dist/component/badge/badge.main.css";
   @import "@gouvfr/dsfr/src/dsfr/core/index";
   @import "@gouvfr/dsfr/src/dsfr/core/style/typography/module/paragraph";
   @import "@gouvfr/dsfr/src/dsfr/core/style/typography/module/list";
   @import "@gouvfr/dsfr/src/dsfr/core/style/display/module/ellipsis";
-  // DSFR Component styles
-  @import "@gouvfr/dsfr/dist/component/badge/badge.main.css";
-
   @include set-shadow-host();
   @include set-dsfr-sizing("badges-group");
 </style>

--- a/src/lib/dsfr/DsfrButton.svelte
+++ b/src/lib/dsfr/DsfrButton.svelte
@@ -163,6 +163,8 @@
   // DSFR Core styles
   @use "src/lib/styles/mixins-dsfr.scss" as *;
   @use "src/module/color";
+  // DSFR Component styles
+  @use "@gouvfr/dsfr/dist/component/button/button.main.css";
   @import "@gouvfr/dsfr/src/dsfr/core/index";
   @import "@gouvfr/dsfr/src/dsfr/core/style/action/module/link";
   @import "@gouvfr/dsfr/src/dsfr/core/style/action/module/button";
@@ -174,9 +176,6 @@
   @import "@gouvfr/dsfr/src/dsfr/core/style/reset/module/box-sizing";
   @import "@gouvfr/dsfr/src/dsfr/core/style/reset/module/tap-highlight";
   @import "@gouvfr/dsfr/src/dsfr/core/style/icon/module";
-  // DSFR Component styles
-  @import "@gouvfr/dsfr/dist/component/button/button.main.css";
-
   @include set-shadow-host("inline-flex", $tag: "dsfr-button") {
     &:has(.fr-btn--centered) {
       --component-width: 100%;

--- a/src/lib/dsfr/DsfrButtonsGroup.svelte
+++ b/src/lib/dsfr/DsfrButtonsGroup.svelte
@@ -158,6 +158,8 @@
   // DSFR Core styles
   @use "src/lib/styles/mixins-dsfr.scss" as *;
   @use "src/module/color";
+  // DSFR Component styles
+  @use "@gouvfr/dsfr/dist/component/button/button.main.css";
   @import "@gouvfr/dsfr/src/dsfr/core/index";
   @import "@gouvfr/dsfr/src/dsfr/core/style/action/module/link";
   @import "@gouvfr/dsfr/src/dsfr/core/style/action/module/button";
@@ -170,9 +172,6 @@
   @import "@gouvfr/dsfr/src/dsfr/core/style/reset/module/box-sizing";
   @import "@gouvfr/dsfr/src/dsfr/core/style/reset/module/tap-highlight";
   @import "@gouvfr/dsfr/src/dsfr/core/style/icon/module";
-  // DSFR Component styles
-  @import "@gouvfr/dsfr/dist/component/button/button.main.css";
-
   @include set-shadow-host();
   @include set-dsfr-sizing("btns-group");
   @include set-dsfr-sizing("btn") {

--- a/src/lib/dsfr/DsfrCallout.svelte
+++ b/src/lib/dsfr/DsfrCallout.svelte
@@ -83,13 +83,12 @@
 <style lang="scss">
   // DSFR Core styles
   @use "src/lib/styles/mixins-dsfr.scss" as *;
+  // DSFR Component styles
+  @use "@gouvfr/dsfr/dist/component/callout/callout.main.min.css";
   @import "@gouvfr/dsfr/src/dsfr/core/index";
   @import "@gouvfr/dsfr/src/dsfr/core/style/typography/module/heading";
   @import "@gouvfr/dsfr/src/dsfr/core/style/typography/module/paragraph";
   @import "@gouvfr/dsfr/src/dsfr/core/style/icon/module";
-  // DSFR Component styles
-  @import "@gouvfr/dsfr/dist/component/callout/callout.main.min.css";
-
   @include set-shadow-host();
   @include set-dsfr-sizing("callout") {
     &__text:not(:last-child) {

--- a/src/lib/dsfr/DsfrCard.svelte
+++ b/src/lib/dsfr/DsfrCard.svelte
@@ -279,7 +279,7 @@
   @use "@gouvfr/dsfr/src/dsfr/core/main" as *;
   // DSFR Component styles
   @use "@gouvfr/dsfr/dist/component/link/link.main.css";
-  @import "@gouvfr/dsfr/dist/component/card/card.main.css";
+  @use "@gouvfr/dsfr/dist/component/card/card.main.css";
 
   @include set-shadow-host();
   @include set-dsfr-sizing("card") {

--- a/src/lib/dsfr/DsfrCheckbox.svelte
+++ b/src/lib/dsfr/DsfrCheckbox.svelte
@@ -218,6 +218,9 @@
 <style lang="scss">
   // DSFR Core styles
   @use "src/lib/styles/mixins-dsfr.scss" as *;
+  // DSFR Component styles
+  @use "@gouvfr/dsfr/dist/component/form/form.main.css";
+  @use "@gouvfr/dsfr/dist/component/checkbox/checkbox.main.css";
   @import "@gouvfr/dsfr/src/dsfr/core/index";
   @import "@gouvfr/dsfr/src/dsfr/core/style/action/module/input";
   @import "@gouvfr/dsfr/src/dsfr/core/style/action/module/focus";
@@ -228,10 +231,6 @@
   @import "@gouvfr/dsfr/src/dsfr/core/style/reset/module/tap-highlight";
   @import "@gouvfr/dsfr/src/dsfr/core/style/scheme";
   @include _core-scheme;
-  // DSFR Component styles
-  @import "@gouvfr/dsfr/dist/component/form/form.main.css";
-  @import "@gouvfr/dsfr/dist/component/checkbox/checkbox.main.css";
-
   @include set-shadow-host();
   @include set-dsfr-sizing("checkbox-group") {
     @include set-themeable-checkbox();

--- a/src/lib/dsfr/DsfrCheckboxesGroup.svelte
+++ b/src/lib/dsfr/DsfrCheckboxesGroup.svelte
@@ -257,6 +257,9 @@
 <style lang="scss">
   // DSFR Core styles
   @use "src/lib/styles/mixins-dsfr.scss" as *;
+  // DSFR Component styles
+  @use "@gouvfr/dsfr/dist/component/form/form.main.css";
+  @use "@gouvfr/dsfr/dist/component/checkbox/checkbox.main.css";
   @import "@gouvfr/dsfr/src/dsfr/core/index";
   @import "@gouvfr/dsfr/src/dsfr/core/style/typography/module/typography";
   @import "@gouvfr/dsfr/src/dsfr/core/style/typography/module/font-weight";
@@ -269,10 +272,6 @@
   @import "@gouvfr/dsfr/src/dsfr/core/style/reset/module/tap-highlight";
   @import "@gouvfr/dsfr/src/dsfr/core/style/scheme";
   @include _core-scheme;
-  // DSFR Component styles
-  @import "@gouvfr/dsfr/dist/component/form/form.main.css";
-  @import "@gouvfr/dsfr/dist/component/checkbox/checkbox.main.css";
-
   @include set-shadow-host();
   @include set-dsfr-sizing("fieldset");
   @include set-dsfr-sizing("checkbox-group") {

--- a/src/lib/dsfr/DsfrConnect.svelte
+++ b/src/lib/dsfr/DsfrConnect.svelte
@@ -78,6 +78,8 @@
 <style lang="scss">
   // DSFR Core styles
   @use "src/lib/styles/mixins-dsfr.scss" as *;
+  // DSFR Component styles
+  @use "@gouvfr/dsfr/dist/component/connect/connect.main.css";
   @import "@gouvfr/dsfr/src/dsfr/core/index";
   @import "@gouvfr/dsfr/src/dsfr/core/style/action/module/link";
   @import "@gouvfr/dsfr/src/dsfr/core/style/action/module/button";
@@ -87,9 +89,6 @@
   @import "@gouvfr/dsfr/src/dsfr/core/style/typography/module/paragraph";
   @import "@gouvfr/dsfr/src/dsfr/core/style/reset/module/box-sizing";
   @import "@gouvfr/dsfr/src/dsfr/core/style/reset/module/tap-highlight";
-  // DSFR Component styles
-  @import "@gouvfr/dsfr/dist/component/connect/connect.main.css";
-
   @include set-shadow-host();
   @include set-dsfr-sizing("connect-group");
 

--- a/src/lib/dsfr/DsfrContent.svelte
+++ b/src/lib/dsfr/DsfrContent.svelte
@@ -108,6 +108,9 @@
 <style lang="scss">
   // DSFR Core styles
   @use "src/lib/styles/mixins-dsfr.scss" as *;
+  // DSFR Component styles
+  @use "@gouvfr/dsfr/dist/component/content/content.main.css";
+  @use "@gouvfr/dsfr/dist/component/link/link.main.css";
   @import "@gouvfr/dsfr/src/dsfr/core/index";
   @import "@gouvfr/dsfr/src/dsfr/core/style/action/module/link";
   @import "@gouvfr/dsfr/src/dsfr/core/style/action/module/focus";
@@ -118,10 +121,6 @@
   @import "@gouvfr/dsfr/src/dsfr/core/style/media/module/iframe";
   @import "@gouvfr/dsfr/src/dsfr/core/style/media/module/ratio";
   @import "@gouvfr/dsfr/src/dsfr/core/style/media/module/responsive";
-  // DSFR Component styles
-  @import "@gouvfr/dsfr/dist/component/content/content.main.css";
-  @import "@gouvfr/dsfr/dist/component/link/link.main.css";
-
   @include set-shadow-host();
   @include set-dsfr-sizing("content-media");
 </style>

--- a/src/lib/dsfr/DsfrDropdown.svelte
+++ b/src/lib/dsfr/DsfrDropdown.svelte
@@ -301,6 +301,8 @@
 <style lang="scss">
   // DSFR Core styles
   @use "src/lib/styles/mixins-dsfr.scss" as *;
+  @use "@gouvfr/dsfr/dist/core/core.min.css";
+  @use "@gouvfr/dsfr/dist/component/navigation/navigation.main.min.css";
   @import "@gouvfr/dsfr/src/dsfr/core/index";
   // @import "@gouvfr/dsfr/src/dsfr/core/style/action/module/link";
   // @import "@gouvfr/dsfr/src/dsfr/core/style/action/module/button";
@@ -319,9 +321,6 @@
   // @import "@gouvfr/dsfr/src/dsfr/component/navigation/style/module/menu";
   // @import "@gouvfr/dsfr/src/dsfr/component/navigation/style/scheme";
   // @include _navigation-scheme;
-
-  @import "@gouvfr/dsfr/dist/core/core.min.css";
-  @import "@gouvfr/dsfr/dist/component/navigation/navigation.main.min.css";
 
   // DSFR Dropdown
   @include set-shadow-host("inline-flex");

--- a/src/lib/dsfr/DsfrFooter.svelte
+++ b/src/lib/dsfr/DsfrFooter.svelte
@@ -282,6 +282,9 @@
 <style lang="scss">
   // DSFR Core styles
   @use "src/lib/styles/mixins-dsfr.scss" as *;
+  // DSFR Component styles
+  @use "@gouvfr/dsfr/dist/component/logo/logo.main.css";
+  @use "@gouvfr/dsfr/dist/component/footer/footer.main.css";
   @import "@gouvfr/dsfr/src/dsfr/core/index";
   @import "@gouvfr/dsfr/src/dsfr/core/style/action/module/link";
   @import "@gouvfr/dsfr/src/dsfr/core/style/action/module/focus";
@@ -294,10 +297,6 @@
   @import "@gouvfr/dsfr/src/dsfr/core/style/reset/module/tap-highlight";
   @import "@gouvfr/dsfr/src/dsfr/core/style/grid/module";
   @import "@gouvfr/dsfr/src/dsfr/core/style/outdated";
-  // DSFR Component styles
-  @import "@gouvfr/dsfr/dist/component/logo/logo.main.css";
-  @import "@gouvfr/dsfr/dist/component/footer/footer.main.css";
-
   @include set-shadow-host();
   @include set-dsfr-sizing("footer") {
     &--compact {

--- a/src/lib/dsfr/DsfrHeader.svelte
+++ b/src/lib/dsfr/DsfrHeader.svelte
@@ -477,6 +477,11 @@
 <style lang="scss">
   // DSFR Core styles
   @use "src/lib/styles/mixins-dsfr.scss" as *;
+  // DSFR Component styles
+  @use "@gouvfr/dsfr/dist/component/logo/logo.main.min.css";
+  @use "@gouvfr/dsfr/dist/component/header/header.main.css";
+  @use "@gouvfr/dsfr/dist/component/modal/modal.main.min.css";
+  @use "@gouvfr/dsfr/dist/component/button/button.main.css";
   @import "@gouvfr/dsfr/src/dsfr/core/index";
   @import "@gouvfr/dsfr/src/dsfr/core/style/action/module";
   @import "@gouvfr/dsfr/src/dsfr/core/style/typography/module/paragraph";
@@ -488,12 +493,6 @@
   @import "@gouvfr/dsfr/src/dsfr/core/style/collapse/module";
   @import "@gouvfr/dsfr/src/dsfr/core/style/scheme";
   @include _core-scheme();
-  // DSFR Component styles
-  @import "@gouvfr/dsfr/dist/component/logo/logo.main.min.css";
-  @import "@gouvfr/dsfr/dist/component/header/header.main.css";
-  @import "@gouvfr/dsfr/dist/component/modal/modal.main.min.css";
-  @import "@gouvfr/dsfr/dist/component/button/button.main.css";
-
   @include set-shadow-host();
   @include set-dsfr-sizing("header") {
     &__service-title {

--- a/src/lib/dsfr/DsfrHighlight.svelte
+++ b/src/lib/dsfr/DsfrHighlight.svelte
@@ -45,14 +45,13 @@
 <style lang="scss">
   // DSFR Core styles
   @use "src/lib/styles/mixins-dsfr.scss" as *;
+  // DSFR Component styles
+  @use "@gouvfr/dsfr/dist/component/highlight/highlight.main.min.css";
   @import "@gouvfr/dsfr/src/dsfr/core/index";
   @import "@gouvfr/dsfr/src/dsfr/core/style/typography/module/paragraph";
   @import "@gouvfr/dsfr/src/dsfr/core/style/typography/module/font-weight";
   @import "@gouvfr/dsfr/src/dsfr/core/style/typography/module/typography";
   @import "@gouvfr/dsfr/src/dsfr/core/style/reset/module/box-sizing";
-  // DSFR Component styles
-  @import "@gouvfr/dsfr/dist/component/highlight/highlight.main.min.css";
-
   @include set-shadow-host();
   @include set-dsfr-sizing("highlight");
 </style>

--- a/src/lib/dsfr/DsfrInput.svelte
+++ b/src/lib/dsfr/DsfrInput.svelte
@@ -308,6 +308,9 @@
 <style lang="scss">
   // DSFR Core styles
   @use "src/lib/styles/mixins-dsfr.scss" as *;
+  // DSFR Component styles
+  @use "@gouvfr/dsfr/dist/component/form/form.main.css";
+  @use "@gouvfr/dsfr/dist/component/input/input.main.css";
   @import "@gouvfr/dsfr/src/dsfr/core/index";
   @import "@gouvfr/dsfr/src/dsfr/core/style/action/module/input";
   @import "@gouvfr/dsfr/src/dsfr/core/style/action/module/focus";
@@ -317,10 +320,6 @@
   @import "@gouvfr/dsfr/src/dsfr/core/style/reset/module/box-sizing";
   @import "@gouvfr/dsfr/src/dsfr/core/style/reset/module/tap-highlight";
   @import "@gouvfr/dsfr/src/dsfr/core/style/icon/module";
-  // DSFR Component styles
-  @import "@gouvfr/dsfr/dist/component/form/form.main.css";
-  @import "@gouvfr/dsfr/dist/component/input/input.main.css";
-
   @include set-shadow-host();
   @include set-dsfr-sizing("input-group");
 

--- a/src/lib/dsfr/DsfrLogo.svelte
+++ b/src/lib/dsfr/DsfrLogo.svelte
@@ -29,12 +29,11 @@
 <style lang="scss">
   // DSFR Core styles
   @use "src/lib/styles/mixins-dsfr.scss" as *;
+  // DSFR Component styles
+  @use "@gouvfr/dsfr/dist/component/logo/logo.main.css";
   @import "@gouvfr/dsfr/src/dsfr/core/index";
   @import "@gouvfr/dsfr/src/dsfr/core/style/typography/module/paragraph";
   @import "@gouvfr/dsfr/src/dsfr/core/style/reset/module/box-sizing";
-  // DSFR Component styles
-  @import "@gouvfr/dsfr/dist/component/logo/logo.main.css";
-
   @include set-shadow-host("inline-block");
   @include set-dsfr-sizing("logo");
 </style>

--- a/src/lib/dsfr/DsfrModal.svelte
+++ b/src/lib/dsfr/DsfrModal.svelte
@@ -200,6 +200,8 @@
 
 <style lang="scss">
   @use "src/lib/styles/mixins-dsfr.scss" as *;
+  @use "@gouvfr/dsfr/dist/component/modal/modal.main.css";
+  @use "@gouvfr/dsfr/dist/component/button/button.main.css";
   @import "@gouvfr/dsfr/src/dsfr/core/index";
   @import "@gouvfr/dsfr/src/dsfr/core/style/action/module/button";
   @import "@gouvfr/dsfr/src/dsfr/core/style/action/module/focus";
@@ -211,8 +213,6 @@
   @import "@gouvfr/dsfr/src/dsfr/core/style/grid/module";
   @import "@gouvfr/dsfr/src/dsfr/core/style/scheme";
   @include _core-scheme();
-  @import "@gouvfr/dsfr/dist/component/modal/modal.main.css";
-  @import "@gouvfr/dsfr/dist/component/button/button.main.css";
 
   @include set-shadow-host();
   @include set-dsfr-sizing("modal") {

--- a/src/lib/dsfr/DsfrPagination.svelte
+++ b/src/lib/dsfr/DsfrPagination.svelte
@@ -225,6 +225,8 @@
 <style lang="scss">
   // DSFR Core styles
   @use "src/lib/styles/mixins-dsfr.scss" as *;
+  // DSFR Component styles
+  @use "@gouvfr/dsfr/dist/component/pagination/pagination.main.css";
   @import "@gouvfr/dsfr/src/dsfr/core/index";
   @import "@gouvfr/dsfr/src/dsfr/core/style/action/module/link";
   @import "@gouvfr/dsfr/src/dsfr/core/style/action/module/focus";
@@ -233,9 +235,6 @@
   @import "@gouvfr/dsfr/src/dsfr/core/style/typography/module/list";
   @import "@gouvfr/dsfr/src/dsfr/core/style/reset/module/box-sizing";
   @import "@gouvfr/dsfr/src/dsfr/core/style/reset/module/tap-highlight";
-  // DSFR Component styles
-  @import "@gouvfr/dsfr/dist/component/pagination/pagination.main.css";
-
   @include set-shadow-host($tag: "dsfr-pagination");
   @include set-dsfr-sizing("pagination") {
     &__link {

--- a/src/lib/dsfr/DsfrRadio.svelte
+++ b/src/lib/dsfr/DsfrRadio.svelte
@@ -113,6 +113,9 @@
 <style lang="scss">
   // DSFR Core styles
   @use "src/lib/styles/mixins-dsfr.scss" as *;
+  // DSFR Component styles
+  @use "@gouvfr/dsfr/dist/component/form/form.main.css";
+  @use "@gouvfr/dsfr/dist/component/radio/radio.main.css";
   @import "@gouvfr/dsfr/src/dsfr/core/index";
   @import "@gouvfr/dsfr/src/dsfr/core/style/action/module/input";
   @import "@gouvfr/dsfr/src/dsfr/core/style/action/module/focus";
@@ -121,10 +124,6 @@
   @import "@gouvfr/dsfr/src/dsfr/core/style/action/module/disabled";
   @import "@gouvfr/dsfr/src/dsfr/core/style/reset/module/box-sizing";
   @import "@gouvfr/dsfr/src/dsfr/core/style/reset/module/tap-highlight";
-  // DSFR Component styles
-  @import "@gouvfr/dsfr/dist/component/form/form.main.css";
-  @import "@gouvfr/dsfr/dist/component/radio/radio.main.css";
-
   @include set-shadow-host();
   @include set-dsfr-sizing("radio-group");
 </style>

--- a/src/lib/dsfr/DsfrRadiosGroup.svelte
+++ b/src/lib/dsfr/DsfrRadiosGroup.svelte
@@ -247,6 +247,9 @@
 <style lang="scss">
   // DSFR Core styles
   @use "src/lib/styles/mixins-dsfr.scss" as *;
+  // DSFR Component styles
+  @use "@gouvfr/dsfr/dist/component/form/form.main.css";
+  @use "@gouvfr/dsfr/dist/component/radio/radio.main.css";
   @import "@gouvfr/dsfr/src/dsfr/core/index";
   @import "@gouvfr/dsfr/src/dsfr/core/style/typography/module/typography";
   @import "@gouvfr/dsfr/src/dsfr/core/style/typography/module/font-weight";
@@ -257,10 +260,6 @@
   @import "@gouvfr/dsfr/src/dsfr/core/style/action/module/disabled";
   @import "@gouvfr/dsfr/src/dsfr/core/style/reset/module/box-sizing";
   @import "@gouvfr/dsfr/src/dsfr/core/style/reset/module/tap-highlight";
-  // DSFR Component styles
-  @import "@gouvfr/dsfr/dist/component/form/form.main.css";
-  @import "@gouvfr/dsfr/dist/component/radio/radio.main.css";
-
   @include set-shadow-host();
   @include set-dsfr-sizing("fieldset");
 </style>

--- a/src/lib/dsfr/DsfrRange.svelte
+++ b/src/lib/dsfr/DsfrRange.svelte
@@ -315,16 +315,15 @@
 <style lang="scss">
   // DSFR Core styles
   @use "src/lib/styles/mixins-dsfr.scss" as *;
+  // DSFR Component styles
+  @use "@gouvfr/dsfr/dist/component/form/form.main.css";
+  @use "@gouvfr/dsfr/dist/component/range/range.main.css";
   @import "@gouvfr/dsfr/src/dsfr/core/index";
   @import "@gouvfr/dsfr/src/dsfr/core/style/action/module/input";
   @import "@gouvfr/dsfr/src/dsfr/core/style/action/module/focus";
   @import "@gouvfr/dsfr/src/dsfr/core/style/action/module/cursor";
   @import "@gouvfr/dsfr/src/dsfr/core/style/action/module/disabled";
   @import "@gouvfr/dsfr/src/dsfr/core/style/reset/module/tap-highlight";
-  // DSFR Component styles
-  @import "@gouvfr/dsfr/dist/component/form/form.main.css";
-  @import "@gouvfr/dsfr/dist/component/range/range.main.css";
-
   @include set-shadow-host();
   @include set-dsfr-sizing("range-group") {
     *,

--- a/src/lib/dsfr/DsfrSearch.svelte
+++ b/src/lib/dsfr/DsfrSearch.svelte
@@ -223,6 +223,10 @@
 <style lang="scss">
   // DSFR Core styles
   @use "src/lib/styles/mixins-dsfr.scss" as *;
+  // DSFR Component styles
+  @use "@gouvfr/dsfr/dist/component/input/input.main.css";
+  @use "@gouvfr/dsfr/dist/component/button/button.main.css";
+  @use "@gouvfr/dsfr/dist/component/search/search.main.css";
   @import "@gouvfr/dsfr/src/dsfr/core/index";
   @import "@gouvfr/dsfr/src/dsfr/core/style/action/module/button";
   @import "@gouvfr/dsfr/src/dsfr/core/style/action/module/input";
@@ -232,11 +236,6 @@
   @import "@gouvfr/dsfr/src/dsfr/core/style/action/module/disabled";
   @import "@gouvfr/dsfr/src/dsfr/core/style/reset/module/box-sizing";
   @import "@gouvfr/dsfr/src/dsfr/core/style/reset/module/tap-highlight";
-  // DSFR Component styles
-  @import "@gouvfr/dsfr/dist/component/input/input.main.css";
-  @import "@gouvfr/dsfr/dist/component/button/button.main.css";
-  @import "@gouvfr/dsfr/dist/component/search/search.main.css";
-
   @include set-shadow-host($tag: "dsfr-search");
   @include set-dsfr-sizing("search-bar");
 </style>

--- a/src/lib/dsfr/DsfrSegmented.svelte
+++ b/src/lib/dsfr/DsfrSegmented.svelte
@@ -182,6 +182,8 @@
 <style lang="scss">
   // DSFR Core styles
   @use "src/lib/styles/mixins-dsfr.scss" as *;
+  // DSFR Component styles
+  @use "@gouvfr/dsfr/dist/component/segmented/segmented.main.min.css";
   @import "@gouvfr/dsfr/src/dsfr/core/index";
   @import "@gouvfr/dsfr/src/dsfr/core/style/action/module/input";
   @import "@gouvfr/dsfr/src/dsfr/core/style/action/module/focus";
@@ -194,9 +196,6 @@
   // DSFR Form
   @import "@gouvfr/dsfr/src/dsfr/component/form/index";
   @import "@gouvfr/dsfr/src/dsfr/component/form/style/module/label";
-  // DSFR Component styles
-  @import "@gouvfr/dsfr/dist/component/segmented/segmented.main.min.css";
-
   @include set-shadow-host("inline-flex");
   @include set-dsfr-sizing("segmented");
 </style>

--- a/src/lib/dsfr/DsfrSelect.svelte
+++ b/src/lib/dsfr/DsfrSelect.svelte
@@ -256,6 +256,9 @@
 <style lang="scss">
   // DSFR Core styles
   @use "src/lib/styles/mixins-dsfr.scss" as *;
+  // DSFR Component styles
+  @use "@gouvfr/dsfr/dist/component/form/form.main.css";
+  @use "@gouvfr/dsfr/dist/component/select/select.main.css";
   @import "@gouvfr/dsfr/src/dsfr/core/index";
   @import "@gouvfr/dsfr/src/dsfr/core/style/action/module/input";
   @import "@gouvfr/dsfr/src/dsfr/core/style/action/module/focus";
@@ -265,10 +268,6 @@
   @import "@gouvfr/dsfr/src/dsfr/core/style/reset/module/box-sizing";
   @import "@gouvfr/dsfr/src/dsfr/core/style/reset/module/tap-highlight";
   @import "@gouvfr/dsfr/src/dsfr/core/style/reset/module/select";
-  // DSFR Component styles
-  @import "@gouvfr/dsfr/dist/component/form/form.main.css";
-  @import "@gouvfr/dsfr/dist/component/select/select.main.css";
-
   @include set-shadow-host($tag: "dsfr-select");
   @include set-dsfr-sizing("select-group");
 

--- a/src/lib/dsfr/DsfrSideMenu.svelte
+++ b/src/lib/dsfr/DsfrSideMenu.svelte
@@ -198,6 +198,8 @@
 <style lang="scss">
   // DSFR Core styles
   @use "src/lib/styles/mixins-dsfr.scss" as *;
+  // DSFR Component styles
+  @use "@gouvfr/dsfr/dist/component/sidemenu/sidemenu.main.css";
   @import "@gouvfr/dsfr/src/dsfr/core/index";
   @import "@gouvfr/dsfr/src/dsfr/core/style/action/module";
   @import "@gouvfr/dsfr/src/dsfr/core/style/typography/module/heading";
@@ -205,9 +207,6 @@
   @import "@gouvfr/dsfr/src/dsfr/core/style/typography/module/list";
   @import "@gouvfr/dsfr/src/dsfr/core/style/collapse/module";
   @import "@gouvfr/dsfr/src/dsfr/core/style/reset/module";
-  // DSFR Component styles
-  @import "@gouvfr/dsfr/dist/component/sidemenu/sidemenu.main.css";
-
   @include set-shadow-host();
   @include set-dsfr-sizing("sidemenu") {
     &,

--- a/src/lib/dsfr/DsfrSkipLink.svelte
+++ b/src/lib/dsfr/DsfrSkipLink.svelte
@@ -43,13 +43,12 @@
 <style lang="scss">
   // DSFR Core styles
   @use "src/lib/styles/mixins-dsfr.scss" as *;
+  // DSFR Component styles
+  @use "@gouvfr/dsfr/dist/component/skiplink/skiplink.main.min.css";
   @import "@gouvfr/dsfr/src/dsfr/core/index";
   @import "@gouvfr/dsfr/src/dsfr/core/style/typography/module/list";
   @import "@gouvfr/dsfr/src/dsfr/core/style/grid/module/container";
   @include grid($grid-settings);
-  // DSFR Component styles
-  @import "@gouvfr/dsfr/dist/component/skiplink/skiplink.main.min.css";
-
   @include set-shadow-host();
   @include set-dsfr-sizing("skiplinks");
 </style>

--- a/src/lib/dsfr/DsfrStepper.svelte
+++ b/src/lib/dsfr/DsfrStepper.svelte
@@ -57,14 +57,13 @@
 <style lang="scss">
   // DSFR Core styles
   @use "src/lib/styles/mixins-dsfr.scss" as *;
+  // DSFR Component styles
+  @use "@gouvfr/dsfr/dist/component/stepper/stepper.main.css";
   @import "@gouvfr/dsfr/src/dsfr/core/index";
   @import "@gouvfr/dsfr/src/dsfr/core/style/typography/module/heading";
   @import "@gouvfr/dsfr/src/dsfr/core/style/typography/module/paragraph";
   @import "@gouvfr/dsfr/src/dsfr/core/style/typography/module/font-weight";
   @import "@gouvfr/dsfr/src/dsfr/core/style/reset/module/box-sizing";
-  // DSFR Component styles
-  @import "@gouvfr/dsfr/dist/component/stepper/stepper.main.css";
-
   @include set-shadow-host();
   @include set-dsfr-sizing("stepper");
 </style>

--- a/src/lib/dsfr/DsfrTable.svelte
+++ b/src/lib/dsfr/DsfrTable.svelte
@@ -855,8 +855,8 @@
   // DSFR Core styles
   @use "src/lib/styles/mixins-dsfr.scss" as *;
   // DSFR Component styles
-  @import "@gouvfr/dsfr/dist/component/table/table.main.min.css";
-  @import "@gouvfr/dsfr/dist/component/checkbox/checkbox.main.css";
+  @use "@gouvfr/dsfr/dist/component/table/table.main.min.css";
+  @use "@gouvfr/dsfr/dist/component/checkbox/checkbox.main.css";
 
   @include set-shadow-host();
   @include set-dsfr-sizing("table");

--- a/src/lib/dsfr/DsfrTabnav.svelte
+++ b/src/lib/dsfr/DsfrTabnav.svelte
@@ -119,14 +119,13 @@
 <style lang="scss">
   // DSFR Core styles
   @use "src/lib/styles/mixins-dsfr.scss" as *;
+  // DSFR Component styles
+  @use "@gouvfr/dsfr/dist/component/sidemenu/sidemenu.main.css";
   @import "@gouvfr/dsfr/src/dsfr/core/index";
   @import "@gouvfr/dsfr/src/dsfr/core/style/action/module";
   @import "@gouvfr/dsfr/src/dsfr/core/style/typography/module/list";
   @import "@gouvfr/dsfr/src/dsfr/core/style/collapse/module";
   @import "@gouvfr/dsfr/src/dsfr/core/style/reset/module";
-  // DSFR Component styles
-  @import "@gouvfr/dsfr/dist/component/sidemenu/sidemenu.main.css";
-
   @include set-shadow-host();
   @include set-dsfr-sizing("tabnav");
 

--- a/src/lib/dsfr/DsfrTag.svelte
+++ b/src/lib/dsfr/DsfrTag.svelte
@@ -129,6 +129,8 @@
 <style lang="scss">
   // DSFR Core styles
   @use "src/lib/styles/mixins-dsfr.scss" as *;
+  // DSFR Component styles
+  @use "@gouvfr/dsfr/dist/component/tag/tag.main.css";
   @import "@gouvfr/dsfr/src/dsfr/core/index";
   @import "@gouvfr/dsfr/src/dsfr/core/style/action/module/link";
   @import "@gouvfr/dsfr/src/dsfr/core/style/action/module/button";
@@ -141,9 +143,6 @@
   @import "@gouvfr/dsfr/src/dsfr/core/style/reset/module/box-sizing";
   @import "@gouvfr/dsfr/src/dsfr/core/style/reset/module/tap-highlight";
   @import "@gouvfr/dsfr/src/dsfr/core/style/icon/module";
-  // DSFR Component styles
-  @import "@gouvfr/dsfr/dist/component/tag/tag.main.css";
-
   @include set-shadow-host("inline-flex");
   @include set-dsfr-sizing("tag");
 </style>

--- a/src/lib/dsfr/DsfrTagsGroup.svelte
+++ b/src/lib/dsfr/DsfrTagsGroup.svelte
@@ -124,6 +124,8 @@
 <style lang="scss">
   // DSFR Core styles
   @use "src/lib/styles/mixins-dsfr.scss" as *;
+  // DSFR Component styles
+  @use "@gouvfr/dsfr/dist/component/tag/tag.main.css";
   @import "@gouvfr/dsfr/src/dsfr/core/index";
   @import "@gouvfr/dsfr/src/dsfr/core/style/action/module/link";
   @import "@gouvfr/dsfr/src/dsfr/core/style/action/module/button";
@@ -137,9 +139,6 @@
   @import "@gouvfr/dsfr/src/dsfr/core/style/reset/module/box-sizing";
   @import "@gouvfr/dsfr/src/dsfr/core/style/reset/module/tap-highlight";
   @import "@gouvfr/dsfr/src/dsfr/core/style/icon/module";
-  // DSFR Component styles
-  @import "@gouvfr/dsfr/dist/component/tag/tag.main.css";
-
   @include set-shadow-host();
   @include set-dsfr-sizing("tags-group");
 </style>

--- a/src/lib/dsfr/DsfrTextarea.svelte
+++ b/src/lib/dsfr/DsfrTextarea.svelte
@@ -247,13 +247,12 @@
 <style lang="scss">
   // DSFR Core styles
   @use "src/lib/styles/mixins-dsfr.scss" as *;
+  // DSFR Component styles
+  @use "@gouvfr/dsfr/dist/component/form/form.main.css";
+  @use "@gouvfr/dsfr/dist/component/input/input.main.css";
   @import "@gouvfr/dsfr/src/dsfr/core/index";
   @import "@gouvfr/dsfr/src/dsfr/core/style/action/module";
   @import "@gouvfr/dsfr/src/dsfr/core/style/reset/module";
-  // DSFR Component styles
-  @import "@gouvfr/dsfr/dist/component/form/form.main.css";
-  @import "@gouvfr/dsfr/dist/component/input/input.main.css";
-
   @include set-shadow-host();
   @include set-dsfr-sizing("input-group");
 </style>

--- a/src/lib/dsfr/DsfrTile.svelte
+++ b/src/lib/dsfr/DsfrTile.svelte
@@ -207,6 +207,8 @@
 <style lang="scss">
   // DSFR Core styles
   @use "src/lib/styles/mixins-dsfr.scss" as *;
+  // DSFR Tile
+  @use "@gouvfr/dsfr/dist/component/tile/tile.main.css";
   @import "@gouvfr/dsfr/src/dsfr/core/index";
   @import "@gouvfr/dsfr/src/dsfr/core/style/action/module/link";
   @import "@gouvfr/dsfr/src/dsfr/core/style/action/module/button";
@@ -224,9 +226,6 @@
   @import "@gouvfr/dsfr/src/dsfr/core/style/icon/module";
   @import "@gouvfr/dsfr/src/dsfr/core/style/spacing/module/margin";
   @import "@gouvfr/dsfr/src/dsfr/core/style/spacing/module/elevation";
-  // DSFR Tile
-  @import "@gouvfr/dsfr/dist/component/tile/tile.main.css";
-
   @include set-shadow-host();
   @include set-dsfr-sizing("tile") {
     height: 100%;

--- a/src/lib/dsfr/DsfrToggle.svelte
+++ b/src/lib/dsfr/DsfrToggle.svelte
@@ -145,6 +145,9 @@
 <style lang="scss">
   // DSFR Core styles
   @use "src/lib/styles/mixins-dsfr.scss" as *;
+  // DSFR Components
+  @use "@gouvfr/dsfr/dist/component/form/form.main.css";
+  @use "@gouvfr/dsfr/dist/component/toggle/toggle.main.css";
   @import "@gouvfr/dsfr/src/dsfr/core/index";
   @import "@gouvfr/dsfr/src/dsfr/core/style/action/module/input";
   @import "@gouvfr/dsfr/src/dsfr/core/style/action/module/focus";
@@ -153,10 +156,6 @@
   @import "@gouvfr/dsfr/src/dsfr/core/style/typography/module/paragraph";
   @import "@gouvfr/dsfr/src/dsfr/core/style/reset/module/box-sizing";
   @import "@gouvfr/dsfr/src/dsfr/core/style/reset/module/tap-highlight";
-  // DSFR Components
-  @import "@gouvfr/dsfr/dist/component/form/form.main.css";
-  @import "@gouvfr/dsfr/dist/component/toggle/toggle.main.css";
-
   @include set-shadow-host();
   @include set-dsfr-sizing("toggle") {
     $toggle-width: 40px;

--- a/src/lib/dsfr/DsfrTooltip.svelte
+++ b/src/lib/dsfr/DsfrTooltip.svelte
@@ -205,12 +205,11 @@
 
 <style lang="scss">
   @use "src/lib/styles/mixins-dsfr.scss" as *;
+  @use "@gouvfr/dsfr/dist/component/tooltip/tooltip.main.css";
   @import "@gouvfr/dsfr/src/dsfr/core/index";
   @import "@gouvfr/dsfr/src/dsfr/core/style/placement/module";
   @import "@gouvfr/dsfr/src/dsfr/core/style/scheme";
   @include _core-scheme;
-
-  @import "@gouvfr/dsfr/dist/component/tooltip/tooltip.main.css";
 
   @include set-shadow-host("inline-flex");
   @include set-dsfr-sizing("tooltip");

--- a/src/lib/dsfr/DsfrTranslate.svelte
+++ b/src/lib/dsfr/DsfrTranslate.svelte
@@ -93,6 +93,8 @@
 <style lang="scss">
   // DSFR Core styles
   @use "src/lib/styles/mixins-dsfr.scss" as *;
+  // DSFR Translate
+  @use "@gouvfr/dsfr/dist/component/translate/translate.main.css";
   @import "@gouvfr/dsfr/src/dsfr/core/index";
   @import "@gouvfr/dsfr/src/dsfr/core/style/action/module/link";
   @import "@gouvfr/dsfr/src/dsfr/core/style/action/module/button";
@@ -116,9 +118,6 @@
   @import "@gouvfr/dsfr/src/dsfr/component/navigation/style/module/menu";
   @import "@gouvfr/dsfr/src/dsfr/component/navigation/style/scheme";
   @include _navigation-scheme;
-  // DSFR Translate
-  @import "@gouvfr/dsfr/dist/component/translate/translate.main.css";
-
   @include set-shadow-host("block");
   @include set-dsfr-sizing("translate");
 </style>

--- a/src/lib/dsfr/DsfrUser.svelte
+++ b/src/lib/dsfr/DsfrUser.svelte
@@ -340,16 +340,15 @@
 <style lang="scss">
   // DSFR Core styles
   @use "src/lib/styles/mixins-dsfr.scss" as *;
+  @use "@gouvfr/dsfr/dist/core/core.min.css";
+  // DSFR Navigation
+  @use "@gouvfr/dsfr/dist/component/navigation/navigation.main.min.css";
   @import "@gouvfr/dsfr/src/dsfr/core/index";
-  @import "@gouvfr/dsfr/dist/core/core.min.css";
   // DSFR Button
   @import "@gouvfr/dsfr/src/dsfr/component/button/index";
   @import "@gouvfr/dsfr/src/dsfr/component/button/style/module/default";
   @import "@gouvfr/dsfr/src/dsfr/component/button/style/scheme";
   @include _button-scheme;
-  // DSFR Navigation
-  @import "@gouvfr/dsfr/dist/component/navigation/navigation.main.min.css";
-
   @include set-dsfr-sizing("user") {
     position: relative;
 


### PR DESCRIPTION
## Décrire les changements

Cette PR remplace 60 imports de fichiers CSS compilés du DSFR utilisant `@import` par `@use`, dans 39 composants Svelte.

Les directives `@use` sont placées avant les imports Sass, conformément aux contraintes de Sass. Les commentaires associés (`// DSFR Component styles` et variantes) ont également été déplacés avec les blocs concernés.

Cela supprime les avertissements `@charset must precede all other statements` sans modifier les styles importés.

## Cette PR introduit-elle un "breaking change" ?

- [ ] Yes
- [x] No

## Autres informations

Validations effectuées avec Node.js 24 :

- build Storybook de production réussi ;
- 21 tests unitaires réussis ;
- vérification Prettier réussie ;
- aucun import CSS compilé du DSFR avec `@import` restant ;
- un seul `@charset "UTF-8"` généré, placé au début du fichier CSS Storybook.