### PR TITLE
[COMPOSANT] Corrige les avertissements de réactivité Svelte

### DIFF
--- a/src/lib/composants/CentreAide.svelte
+++ b/src/lib/composants/CentreAide.svelte
@@ -1,7 +1,6 @@
 <svelte:options customElement={{ tag: "lab-anssi-centre-aide", extend: withIconsStyleSheet }} />
 
 <script lang="ts">
-  import { run } from "svelte/legacy";
   import { fly } from "svelte/transition";
   import { MediaQuery } from "svelte/reactivity";
 
@@ -27,16 +26,16 @@
 
   setThemeable($host());
 
-  let liensMisEnForme: { texte: string; href?: string; preventDefault?: boolean; id?: string }[] =
-    $state([]);
-  run(() => {
-    liensMisEnForme = typeof liens === "string" ? JSON.parse(liens) : liens;
+  let liensMisEnForme: Lien[] = $derived.by(() => {
+    const liensFormates = typeof liens === "string" ? JSON.parse(liens) : liens;
 
-    if (!Array.isArray(liensMisEnForme) || liensMisEnForme.some((l) => !l.texte)) {
+    if (!Array.isArray(liensFormates) || liensFormates.some((l) => !l.texte)) {
       throw new Error(
         "Les liens doivent respecter le type : { texte: string; href?: string; preventDefault?: boolean; id?: string }[]",
       );
     }
+
+    return liensFormates;
   });
 
   let ouvert: boolean = $state(false);

--- a/src/lib/composants/MultiSelect.svelte
+++ b/src/lib/composants/MultiSelect.svelte
@@ -75,7 +75,7 @@
 
   const disabledClass = $derived(disabled ? "fr-select-group--disabled" : "");
 
-  let currentValues: string[] = $state(values || []);
+  let currentValues: string[] = $derived(values);
   function handleChange(event: Event) {
     // REVIEW deprecate this event in favor of valueschanged
     $host().dispatchEvent(

--- a/src/lib/composants/Reactions.svelte
+++ b/src/lib/composants/Reactions.svelte
@@ -45,7 +45,7 @@
   let popoverShown = $state(false);
 
   let popoverElement: HTMLElement | null = null;
-  let tooltipElement: HTMLElement | null = null;
+  let tooltipElement = $state<HTMLElement | null>(null);
   let triggerButton: HTMLElement | null = null;
 
   /**

--- a/src/lib/composants/blog/ListeArticles.svelte
+++ b/src/lib/composants/blog/ListeArticles.svelte
@@ -22,13 +22,13 @@
 
   let { articles, categories, idCategorieChoisie = $bindable("tous") }: Props = $props();
 
-  const optionsFiltrage = [
+  const optionsFiltrage = $derived([
     { label: "Tous les articles", valeur: "tous" },
     ...Object.entries(categories).map(([idCategorie, donnees]) => ({
       label: donnees.label,
       valeur: idCategorie,
     })),
-  ];
+  ]);
 
   let articlesVisibles = $derived(
     idCategorieChoisie === "tous"

--- a/src/lib/composants/blog/PageCrisp.svelte
+++ b/src/lib/composants/blog/PageCrisp.svelte
@@ -9,8 +9,6 @@
 />
 
 <script lang="ts">
-  import { run } from "svelte/legacy";
-
   import type { TableDesMatieres } from "$lib/types";
   import SommaireMobile from "$lib/composants/blog/SommaireMobile.svelte";
   import { onDestroy, tick } from "svelte";
@@ -52,7 +50,7 @@
     lesSections.forEach((s) => observateurDIntersection.observe(s));
   };
 
-  run(() => {
+  $effect(() => {
     if (contenu) tick().then(observeLesSections);
   });
 
@@ -81,7 +79,7 @@
     }
   };
 
-  run(() => {
+  $effect(() => {
     if (contenu) scroll(window.location.hash);
   });
 

--- a/src/lib/composants/mes-services-cyber/lien/LienDiagnosticCyber.svelte
+++ b/src/lib/composants/mes-services-cyber/lien/LienDiagnosticCyber.svelte
@@ -9,9 +9,9 @@
   }
 
   let { lien, versExterne = false }: Props = $props();
-  let target = versExterne ? "_blank" : "_self";
-  let rel = versExterne ? "noreferrer" : undefined;
-  let icone = versExterne ? "lien-externe" : "lien-interne";
+  let target = $derived(versExterne ? "_blank" : "_self");
+  let rel = $derived(versExterne ? "noreferrer" : undefined);
+  let icone = $derived(versExterne ? "lien-externe" : "lien-interne");
 </script>
 
 <div class="racine">

--- a/src/lib/dsfr/DsfrDropdown.svelte
+++ b/src/lib/dsfr/DsfrDropdown.svelte
@@ -83,7 +83,7 @@
     disabled,
   }: Props = $props();
   let dropdown: HTMLElement;
-  let effectiveAlign = $state<"left" | "right">(align);
+  let effectiveAlign = $derived<"left" | "right">(align);
 
   const isLinks = $derived(contentType === "links");
   const isButtons = $derived(contentType === "buttons");

--- a/src/lib/dsfr/DsfrSegmented.svelte
+++ b/src/lib/dsfr/DsfrSegmented.svelte
@@ -65,11 +65,7 @@
   }: Props = $props();
 
   // `checked` sert de fallback si `value` n'est pas fourni
-  let currentValue = $state(value ?? elements.find((e) => e.checked)?.value?.toString());
-
-  $effect(() => {
-    currentValue = value;
-  });
+  let currentValue = $derived(value ?? elements.find((e) => e.checked)?.value?.toString());
 
   let fieldsetEl: HTMLFieldSetElement | undefined = $state();
   let elementsEl: HTMLDivElement | undefined = $state();

--- a/src/lib/dsfr/DsfrTable.svelte
+++ b/src/lib/dsfr/DsfrTable.svelte
@@ -338,7 +338,7 @@
   let isServerSide = $derived(totalRows !== undefined);
   let nbRows = $derived(isServerSide ? (totalRows ?? 0) : (computedTbodies[0]?.length ?? 0));
 
-  let rowsPerPage = $state(itemsPerPage[0]);
+  let rowsPerPage = $derived(itemsPerPage[0]);
   let currentPage = $state(1);
   let totalPages = $derived(Math.ceil(nbRows / rowsPerPage));
 

--- a/src/lib/dsfr/DsfrTranslate.svelte
+++ b/src/lib/dsfr/DsfrTranslate.svelte
@@ -47,7 +47,7 @@
   let expanded = $state(false);
 
   // Récupère l'itam dans le tableau `languages` qui est actif
-  const activeLanguage = languages.find((language) => language.active) ?? languages[0];
+  const activeLanguage = $derived(languages.find((language) => language.active) ?? languages[0]);
 </script>
 
 <div {id} class="fr-translate fr-nav">

--- a/src/lib/dsfr/DsfrUser.svelte
+++ b/src/lib/dsfr/DsfrUser.svelte
@@ -83,7 +83,7 @@
   }: Props = $props();
 
   let container: HTMLElement;
-  let effectiveAlign = $state<"left" | "right">(align);
+  let effectiveAlign = $derived<"left" | "right">(align);
   let expanded = $state(false);
   const iconClass = $derived<boolean | string>(
     buttonIcon && `fr-btn--icon-left ${setIconClass(buttonIcon)}`,


### PR DESCRIPTION
## Décrire les changements

Cette PR corrige les 13 avertissements de réactivité signalés par Svelte et supprime les derniers usages de `svelte/legacy` dans 11 composants :

- 12 avertissements `state_referenced_locally` ;
- 1 avertissement `non_reactive_update` ;
- correction du warning d’exécution `legacy_recursive_reactive_block` dans `CentreAide` ;
- remplacement des derniers appels à `run()` dans `CentreAide` et `PageCrisp`.

Les valeurs calculées depuis les propriétés utilisent désormais `$derived`. Les effets de `PageCrisp` utilisent `$effect` et la référence DOM de l’infobulle du composant `Reactions` utilise `$state`.

Ces changements permettent aux composants de réagir aux mises à jour de leurs propriétés après leur initialisation et retirent entièrement la dépendance à `svelte/legacy`.

## Cette PR introduit-elle un "breaking change" ?

- [ ] Yes
- [x] No

## Autres informations

Validations effectuées avec Node.js 24 :

- builds Storybook de production et Web Components réussis ;
- 21 tests unitaires réussis ;
- vérification Prettier réussie ;
- aucun avertissement `state_referenced_locally` restant ;
- aucun avertissement `non_reactive_update` restant ;
- aucun import depuis `svelte/legacy` restant ;
- aucun appel à `run()` restant ;
- tests Chrome de `CentreAide` et `PageCrisp` sans `legacy_recursive_reactive_block` ni erreur de page.