### PR TITLE
[COMPOSANT] Corrige les avertissements d’accessibilité Svelte

### DIFF
--- a/src/lib/composants/Alerte.svelte
+++ b/src/lib/composants/Alerte.svelte
@@ -29,6 +29,7 @@
       {#if fermable}
         <button
           class="fermer"
+          aria-label="Fermer l’alerte"
           onclick={() => {
             estOuvert = false;
           }}

--- a/src/lib/dsfr/DsfrCheckboxesGroup.svelte
+++ b/src/lib/dsfr/DsfrCheckboxesGroup.svelte
@@ -193,7 +193,6 @@
 <fieldset
   class={["fr-fieldset", `fr-fieldset--${computedStatus}`]}
   aria-labelledby={`${id}-legend ${id}-messages`}
-  role="group"
   {id}
   {disabled}
   {form}

--- a/src/lib/dsfr/DsfrRadiosGroup.svelte
+++ b/src/lib/dsfr/DsfrRadiosGroup.svelte
@@ -187,7 +187,6 @@
 <fieldset
   class={["fr-fieldset", `fr-fieldset--${computedStatus}`]}
   aria-labelledby={`${id}-legend ${id}-messages`}
-  role="group"
   {id}
   {disabled}
   {form}

--- a/src/lib/dsfr/DsfrTagsGroup.svelte
+++ b/src/lib/dsfr/DsfrTagsGroup.svelte
@@ -92,6 +92,7 @@
 </script>
 
 {#snippet tagItem(tag: Tag)}
+  <!-- svelte-ignore a11y_no_static_element_interactions (pressable tags render as native buttons) -->
   <svelte:element
     this={markup}
     class={[


### PR DESCRIPTION
## Décrire les changements

- Ajout d'un aria-label manquant
- suppression d'un faux positif

Les libellés et relations ARIA existants sont conservés.

## Cette PR introduit-elle un "breaking change" ?

- [ ] Yes
- [x] No

