### PR TITLE
[CORRECTION] Permets de voir le focus

### DIFF
--- a/src/lib/composants/carrousel-tuiles/CarrouselTuiles.svelte
+++ b/src/lib/composants/carrousel-tuiles/CarrouselTuiles.svelte
@@ -158,6 +158,7 @@
       display: flex;
       overflow-x: auto;
       gap: var(--espacement);
+      padding: 2px 0;
 
       scroll-snap-type: x mandatory;
       scroll-behavior: smooth;


### PR DESCRIPTION
...en ajoutant un espace au-dessus des tuiles du carrousel. Sinon, le focus est tronqué par l’overflow.
## Cette PR introduit-elle un "breaking change" ?

- [ ] Yes
- [x] No

